### PR TITLE
Added initial admin backend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ php bin/console app:elasticsearch:reindex
 
 If you didn't use Vagrant and use an existing MySQL database, adjust the `app/config/parameters.yml` file to match your database credentials.
 
+# Prepare web assets for EasyAdmin
+php bin/console assets:install --symlink
+
 # Running the application
 
 ```

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -18,6 +18,7 @@ class AppKernel extends Kernel
             new AppBundle\AppBundle(),
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
+            new JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,7 +10,7 @@ parameters:
 
 framework:
     #esi: ~
-    #translator: { fallbacks: ['%locale%'] }
+    translator: { fallbacks: ['%locale%'] }
     secret: '%secret%'
     router:
         resource: '%kernel.root_dir%/config/routing.yml'
@@ -109,3 +109,20 @@ stof_doctrine_extensions:
             loggable: true
             sluggable: true
             blameable: true
+
+easy_admin:
+    entities:
+        Adventure:
+            class: AppBundle\Entity\Adventure
+            label: 'Adventures'
+            list:
+                title: "Adventures"
+                fields: ['id', 'title', 'approved', 'info']
+            edit:
+                fields: ['id', 'title']
+
+        User:
+            class: AppBundle\Entity\User
+            label: 'Users'
+            list:
+                title: "Users"

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,3 +1,8 @@
+easy_admin_bundle:
+    resource: "@EasyAdminBundle/Controller/"
+    type:     annotation
+    prefix:   /admin
+
 app:
     resource: '@AppBundle/Controller/'
     type: annotation

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "elasticsearch/elasticsearch": "^5.2",
         "fzaninotto/faker": "^1.6",
         "incenteev/composer-parameter-handler": "^2.0",
+        "javiereguiluz/easyadmin-bundle": "^1.16",    
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "stof/doctrine-extensions-bundle": "^1.2",


### PR DESCRIPTION
I added an initial admin backend using EasyAdmin. You can browse to [http://localhost:8000/app_dev.php/admin/](http://localhost:8000/app_dev.php/admin/) to see it (assuming you have content and can run the app locally).

Having an admin backend will make it MUCH easier to moderate the site. Currently, the only way to curate content is to scroll through the same frontend available to all users, and there is no way to add new users or add/change user roles as an admin. This is inefficient. A proper admin panel will give Matt, or whoever else acts as an admin, the ability to make more admins and mods to help share the curating load.

Currently, the initial admin does not feature any user authentication. Once we add that, we can define "mod" as a user role. Mods will be able to log into the admin panel and view, edit, and delete adventures. In other words, they will be able to act as editors without having to scroll through the front end. 

As you'll see, the current admin site is quite bare bones:

- You can view, edit, and delete all adventures and users
- You can sort by any of the listed fields. For example, you can sort adventures alphabetically by title.
- For adventures, you can toggle the "Approved" status (again, useful for moderating).

It should be trivial to integrate the other adventure data fields into the admin site, so moderators have full visibility and control over all content. However, I can't figure out what other variables cmfcmf has included in the adventure `info` structure. I think he's refactoring the adventure field stuff, so we can expand the admin functionality once that's done.