### PR TITLE
Easy way to access adventure info

### DIFF
--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -153,49 +153,45 @@
                             {% for adventure in adventures %}                            
                                 <div class="card mb-3">
                                     <div class="card-block">
+                                        <img src="{{ adventure.thumbnailUrl.0 }}" class="ml-1 pull-right" style="max-width: 120px; max-height: 140px;" />
                                         <h4 class="card-title">
                                             <a href="{{ path('adventure_show', { 'slug': adventure.slug }) }}">
                                                 {{ adventure.title }}
                                             </a>
                                         </h4>
                                         <!--h6 class="card-subtitle mb-2 text-muted">Search score: {{ adventure.score }}</h6-->
-                                        <!--pre>
-                                            {{ dump(adventure.info) }}
-                                        </pre-->
-
-                                        <!-- IDEALLY, THERE WOULD BE A FUNCTION THAT CREATES A SHORT DESCRIPTION THAT COULD BE DIRECTLY REFERENCED, INSTEAD OF DOING THIS .info... HACK -->
-                                        <p>{{ adventure.info.14.contents.0|length > 250 ? adventure.info.14.contents.0|slice(0,250) ~ '...' : adventure.info.14.contents.0 }}</p>
+                                        <p>{{ adventure.description.0|easyadmin_truncate(250) }}</p>
+                                        <div class="clearfix"></div>
                                         <hr>
                                         <!-- Quick look info -->
                                         <div class="container-fluid row justify-content-center">
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-gear"></i>
                                                 <p class="text-muted mb-2">System</p>
-                                                <h6>{{adventure.info.2.contents.0}}</h6>
+                                                <h6>{{adventure.system.0}}</h6>
                                             </div>
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-globe"></i>
                                                 <p class="text-muted mb-2">Setting</p>
-                                                <h6>{{adventure.info.4.contents.0}}</h6>
+                                                <h6>{{adventure.setting.0}}</h6>
                                             </div>
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-flag"></i>
                                                 <p class="text-muted mb-2">Level</p>
-                                                <h6>{{adventure.info.5.contents.0}}-{{adventure.info.6.contents.0}}</h6>
+                                                <h6>{{adventure.minStartingLevel.0}}-{{adventure.maxStartingLevel.0}}</h6>
                                             </div>
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-tree"></i>
                                                 <p class="text-muted mb-2">Environment</p>
-                                                <h6>{{adventure.info.11.contents.0}}</h6>
+                                                <h6>{{adventure.environments|join(', ')}}</h6>
                                             </div>
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-map"></i>
                                                 <p class="text-muted mb-2">Tactical Maps</p>
-                                                <h6>{% if adventure.info.17.contents.0 %}Yes{% else %}No{% endif%}</h6>
+                                                <h6>{% if adventure.tacticalMaps.0 %}Yes{% else %}No{% endif%}</h6>
                                             </div>
-                                        </div> 
+                                        </div>
                                         <!-- End quick look info -->
-
                                     </div>
                                 </div>
                             {% else %}

--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -153,14 +153,16 @@
                             {% for adventure in adventures %}                            
                                 <div class="card mb-3">
                                     <div class="card-block">
-                                        <img src="{{ adventure.thumbnailUrl.0 }}" class="ml-1 pull-right" style="max-width: 120px; max-height: 140px;" />
+                                        {% if adventure.thumbnailUrl|first %}
+                                            <img src="{{ adventure.thumbnailUrl|first }}" class="ml-1 pull-right" style="max-width: 120px; max-height: 140px;" />
+                                        {% endif %}
                                         <h4 class="card-title">
                                             <a href="{{ path('adventure_show', { 'slug': adventure.slug }) }}">
                                                 {{ adventure.title }}
                                             </a>
                                         </h4>
                                         <!--h6 class="card-subtitle mb-2 text-muted">Search score: {{ adventure.score }}</h6-->
-                                        <p>{{ adventure.description.0|easyadmin_truncate(250) }}</p>
+                                        <p>{{ adventure.description|first|easyadmin_truncate(250) }}</p>
                                         <div class="clearfix"></div>
                                         <hr>
                                         <!-- Quick look info -->
@@ -168,17 +170,17 @@
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-gear"></i>
                                                 <p class="text-muted mb-2">System</p>
-                                                <h6>{{adventure.system.0}}</h6>
+                                                <h6>{{adventure.system|first}}</h6>
                                             </div>
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-globe"></i>
                                                 <p class="text-muted mb-2">Setting</p>
-                                                <h6>{{adventure.setting.0}}</h6>
+                                                <h6>{{adventure.setting|first}}</h6>
                                             </div>
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-flag"></i>
                                                 <p class="text-muted mb-2">Level</p>
-                                                <h6>{{adventure.minStartingLevel.0}}-{{adventure.maxStartingLevel.0}}</h6>
+                                                <h6>{{adventure.minStartingLevel|first}}-{{adventure.maxStartingLevel|first}}</h6>
                                             </div>
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-tree"></i>
@@ -188,7 +190,7 @@
                                             <div class="col-2 text-center">
                                                 <i class="fa fa-map"></i>
                                                 <p class="text-muted mb-2">Tactical Maps</p>
-                                                <h6>{% if adventure.tacticalMaps.0 %}Yes{% else %}No{% endif%}</h6>
+                                                <h6>{% if adventure.tacticalMaps|first %}Yes{% else %}No{% endif%}</h6>
                                             </div>
                                         </div>
                                         <!-- End quick look info -->

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -34,3 +34,6 @@ security:
             logout:
                 path:   /logout
                 target: /
+
+    access_control:
+        - { path: ^/admin, roles: ROLE_ADMIN }

--- a/src/AppBundle/Controller/TagNameController.php
+++ b/src/AppBundle/Controller/TagNameController.php
@@ -15,7 +15,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;use Symfony\Component
  * Tagname controller.
  *
  * @Route("/fields")
- * @Security("is_granted('ROLE_CURATOR')")
+ * @Security("is_granted('ROLE_ADMIN')")
  */
 class TagNameController extends Controller
 {

--- a/src/AppBundle/Entity/AdventureDocument.php
+++ b/src/AppBundle/Entity/AdventureDocument.php
@@ -15,6 +15,101 @@ class AdventureDocument
 
     private $info;
 
+    /**
+     * @var string
+     */
+    private $system;
+
+    /**
+     * @var string
+     */
+    private $publisher;
+
+    /**
+     * @var string
+     */
+    private $setting;
+
+    /**
+     * @var integer
+     */
+    private $minStartingLevel;
+
+    /**
+     * @var integer
+     */
+    private $maxStartingLevel;
+
+    /**
+     * @var integer
+     */
+    private $levelRange;
+
+    /**
+     * @var boolean
+     */
+    private $soloable;
+
+    /**
+     * @var integer
+     */
+    private $numPages;
+
+    /**
+     * @var boolean
+     */
+    private $pregeneratedCharacters;
+
+    /**
+     * @var string[]
+     */
+    private $environments;
+
+    /**
+     * @var string
+     */
+    private $link;
+
+    /**
+     * @var string
+     */
+    private $thumbnailUrl;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @var string[]
+     */
+    private $notableItems;
+
+    /**
+     * @var string[]
+     */
+    private $monsters;
+
+    /**
+     * @var boolean
+     */
+    private $tacticalMaps;
+
+    /**
+     * @var boolean
+     */
+    private $handouts;
+
+    /**
+     * @var string[]
+     */
+    private $villains;
+
+    /**
+     * @var string
+     */
+    private $foundIn;
+
     public function __construct(int $id, string $title, string $slug, array $info, float $score = 0.0)
     {
         $this->id = $id;
@@ -22,6 +117,37 @@ class AdventureDocument
         $this->slug = $slug;
         $this->score = $score;
         $this->info = $info;
+
+        $map = [
+            'Author' => 'author',
+            'System / Edition' => 'system',
+            'Publisher' => 'publisher',
+            'Setting' => 'setting',
+            'Min. Starting Level' => 'minStartingLevel',
+            'Max. Starting Level' => 'maxStartingLevel',
+            'Level Range' => 'levelRange',
+            'Suitable for Solo Play' => 'soloable',
+            'Length (# of Pages)' => 'numPages',
+            'Includes Pregenerated Characters' => 'pregeneratedCharacters',
+            'Environment' => 'environments',
+            'Link' => 'link',
+            'Thumbnail' => 'thumbnailUrl',
+            'Description' => 'description',
+            'Notable Items' => 'notableItems',
+            'Monsters' => 'monsters',
+            'Tactical Maps' => 'tacticalMaps',
+            'Handouts' => 'handouts',
+            'Villains' => 'villains',
+            'Found in ' => 'foundIn'
+        ];
+
+        foreach ($info as $infoObj) {
+            $fieldTitle = $infoObj['meta']->getTitle();
+            if (isset($map[$fieldTitle])) {
+                $fieldName = $map[$fieldTitle];
+                $this->$fieldName = $infoObj['contents'];
+            }
+        }
     }
 
     public static function fromAdventure(Adventure $adventure)
@@ -76,8 +202,160 @@ class AdventureDocument
     /**
      * @return string
      */
-    public function getSlug(): string
+    public function getSlug()
     {
         return $this->slug;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSystem()
+    {
+        return $this->system;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPublisher()
+    {
+        return $this->publisher;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSetting()
+    {
+        return $this->setting;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMinStartingLevel()
+    {
+        return $this->minStartingLevel;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxStartingLevel()
+    {
+        return $this->maxStartingLevel;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLevelRange()
+    {
+        return $this->levelRange;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSoloable()
+    {
+        return $this->soloable;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumPages()
+    {
+        return $this->numPages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPregeneratedCharacters()
+    {
+        return $this->pregeneratedCharacters;
+    }
+
+    /**
+     * @return \string[]
+     */
+    public function getEnvironments()
+    {
+        return $this->environments;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLink()
+    {
+        return $this->link;
+    }
+
+    /**
+     * @return string
+     */
+    public function getThumbnailUrl()
+    {
+        return $this->thumbnailUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return \string[]
+     */
+    public function getNotableItems()
+    {
+        return $this->notableItems;
+    }
+
+    /**
+     * @return \string[]
+     */
+    public function getMonsters()
+    {
+        return $this->monsters;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTacticalMaps()
+    {
+        return $this->tacticalMaps;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHandouts()
+    {
+        return $this->handouts;
+    }
+
+    /**
+     * @return \string[]
+     */
+    public function getVillains()
+    {
+        return $this->villains;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFoundIn()
+    {
+        return $this->foundIn;
     }
 }

--- a/src/AppBundle/Service/FieldUtils.php
+++ b/src/AppBundle/Service/FieldUtils.php
@@ -37,7 +37,7 @@ class FieldUtils
             case 'string':
                 return $faker->name;
             case 'url':
-                return $faker->url;
+                return $faker->imageUrl(260, 300, null, false);
             case 'text':
                 return $faker->realText(2000);
         }


### PR DESCRIPTION
This adds an intermediate map between the info fields and their names. Therefore you are now able to use normalized field names in the adventure index and show templates.
I haven't changed anything in the database yet, but I think this is a good first step to make adjusting the index and show templates easier.

This will of course break if someone changes the title of one of the fields. Therefore I restricted access to the `/fields` and `/admin` interface to users with the `ROLE_ADMIN` role - which nobody currently has. It needs to be given manually to selected people by setting the `roles` column of the `users` table to `ROLE_USER,ROLE_CURATOR,ROLE_ADMIN `.

This should also fix the Frontend and make updating to the latest HEAD possible once more.
This also fixes #10.