### PR TITLE
Update max. password length assertion to match max. length accepted by encoder

### DIFF
--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -57,7 +57,7 @@ class User implements AdvancedUserInterface, \Serializable
 
     /**
      * @Assert\NotBlank()
-     * @Assert\Length(max=4096)
+     * @Assert\Length(max=72)
      */
     private $plainPassword;
 


### PR DESCRIPTION
The BCrypt encoder we use to encode passwords [has a max password length of 72](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php#L22). This updates the assertion accordingly, to display a proper error message when a user tries to register with a longer password.