### PR TITLE
Feature/#55 re-enable search filters

### DIFF
--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -1,18 +1,5 @@
 {% extends 'base.html.twig' %}
 
-{% macro filter_checkbox(field, value, checked, count, hidden) %}
-    <div class="form-check{% if hidden %} d-none{% endif %}">
-        <label class="form-check-label">
-            <input class="form-check-input" type="checkbox" name="f[{{ field.id }}][v][]"
-                   value="{{ value }}"
-                   {% if checked %}checked{% endif %}
-            />
-            {{ value }}
-            <span class="badge-pill badge badge-default">{{ count }}</span>
-        </label>
-    </div>
-{% endmacro %}
-
 {% block body %}
     {% import _self as macros %}
     <div class="container" id="page--search-adventures" data-search-url="{{ path('field_content_search', {id: '__ID__', q: '__Q__'}) }}">
@@ -28,177 +15,17 @@
                     <div class="input-group input-group-lg">
                         <input class="form-control" name="q" type="text" value="{{ q }}" placeholder="goblins, mountains, ..." />
                         <span class="input-group-btn">
-                            <button type="submit" class="btn btn-primary" role="button">Search</button>
+                            <button type="submit" class="btn btn-primary" role="button" id="search-btn">Search</button>
                         </span>
                     </div>
-                    <small class="form-text text-muted">Things you type in here will be split at <code>,</code> and then <code>OR</code>ed. Use the filters below for advanced searches (hit the 'Search' button again after filtering).</small>
+                    <small class="form-text text-muted">Things you type in here will be split at <code>,</code> and then <code>AND</code>ed. Use the filters below for advanced searches (hit the 'Search' button again after filtering).</small>
                     <div class="row my-3">
                         <div class="col-3">
-                            <div class="row no-gutters">
-                                <div class="col-9">
-                                    <select class="form-control mb-3" id="filter-selection" title="Add search filter">
-                                        <option value="">Add Filter</option>
-                                        {% for field in tagNames if not (field.useAsFilter or searchFilter[field.id]|default({e: false})['e']) %}
-                                            <option value="{{ field.id }}">{{ field.title }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                                <div class="col-3">
-                                    <button type="button" role="button" class="btn btn-secondary" id="filter-add">Add</button>
-                                </div>
-                            </div>
-                            {% for field in tagNames if field.type not in ['url'] %}
-                                {% set filter = searchFilter[field.id]|default([]) %}
-                                {% set show = (field.useAsFilter or searchFilter[field.id]|default({e: false})['e']) %}
-                                <div class="card mb-3 filter-card{% if not show %} d-none{% endif %}" id="filter-{{ field.id }}">
-                                    <input type="hidden" name="f[{{ field.id }}][e]" value="{{ show ? '1' : '0' }}" id="filter-{{ field.id }}-enabled">
-                                    <div class="card-block">
-                                        <h4 class="card-title">{{ field.title }}</h4>
-                                        <p class="card-text small">{{ field.description }}</p>
-                                        {% if field.type == 'boolean' %}
-                                            {% set vals = stats['vals_' ~ field.id]['buckets'] %}
-                                            <label class="form-check-label">
-                                                <input class="form-check-input" type="radio"
-                                                       name="f[{{ field.id }}][v]" value=""
-                                                       {% if filter['v']|default('') == '' %}checked{% endif %}
-                                                /> All
-                                            </label>
-                                            <label class="form-check-label">
-                                                <input class="form-check-input" type="radio"
-                                                       name="f[{{ field.id }}][v]" value="1"
-                                                       {% if filter['v']|default('') == '1' %}checked{% endif %}
-                                                /> Yes
-                                            </label>
-                                            <label class="form-check-label">
-                                                <input class="form-check-input" type="radio"
-                                                       name="f[{{ field.id }}][v]" value="0"
-                                                       {% if filter['v']|default('') == '0' %}checked{% endif %}
-                                                /> No
-                                            </label>
-                                        {% elseif field.type == 'integer' %}
-                                            {#
-                                            <div class="filter-slider mt-5 mx-3"
-                                                 data-field-id="{{ field.id }}"
-                                                 data-max="{{ stats['max_' ~ field.id]['value'] }}"
-                                                 data-min="{{ stats['min_' ~ field.id]['value'] }}"></div>
-                                             #}
-                                            <div class="row no-gutters">
-                                                <div class="col">
-                                                    <input type="number" name="f[{{ field.id }}][v][min]" id="filter-{{ field.id }}-min"
-                                                           placeholder="min (inc.)" class="form-control form-control-sm"
-                                                           value="{{ filter['v']|default({min: stats['min_' ~ field.id]['value']})['min'] }}"
-                                                           title="min (inc.)"
-                                                    />
-                                                </div>
-                                                <div class="col">
-                                                    <input type="number" name="f[{{ field.id }}][v][max]" id="filter-{{ field.id }}-max"
-                                                           placeholder="max (inc.)" class="form-control form-control-sm"
-                                                           value="{{ filter['v']|default({max: stats['max_' ~ field.id]['value']})['max'] }}"
-                                                           title="max (inc.)"
-                                                    />
-                                                </div>
-                                            </div>
-                                        {% elseif field.type == 'string' %}
-                                            {% if stats['vals_' ~ field.id]['sum_other_doc_count'] != 0 %}
-                                                {% if filter['v'] is not defined or filter['v'] == [] or filter['v'] == [''] %}
-                                                    {% set filter_vals = [''] %}
-                                                {% else %}
-                                                    {% set filter_vals = filter['v'] %}
-                                                {% endif %}
-                                                {% for filter_val in filter_vals if (filter_val != '' or filter_vals == ['']) %}
-                                                    <div class="input-group filter-input">
-                                                        <input class="w-100 form-control form-control-sm adv-search-input"
-                                                               data-id="{{ field.id }}"
-                                                               placeholder="{{ exampleValues['info_' ~ field.id]|default([field.example])|join(', ') }}"
-                                                               name="f[{{ field.id }}][v][]" value="{{ filter_val }}"
-                                                        />
-                                                        <span class="input-group-btn">
-                                                            <button class="btn btn-sm btn-secondary" type="button" role="button" title="Add another search term">
-                                                                <i class="fa fa-plus"></i>
-                                                            </button>
-                                                        </span>
-                                                    </div>
-                                                {% endfor %}
-                                            {% endif %}
-                                            <div class="filters">
-                                                {% set buckets = stats['vals_' ~ field.id]['buckets'] %}
-                                                {% set showMoreAfter = 5 %}
-                                                {% set valuesUsed = [] %}
-                                                {% for bucket in buckets %}
-                                                    {% set valuesUsed = valuesUsed|merge([bucket.key]) %}
-                                                    {{ macros.filter_checkbox(field, bucket.key, bucket.key in filter['v']|default([]), bucket.doc_count, loop.index0 >= showMoreAfter) }}
-                                                {% endfor %}
-                                                {% for value in filter['v']|default([]) if value != '' and value not in valuesUsed %}
-                                                    {{ macros.filter_checkbox(field, value, true, 0, false) }}
-                                                {% endfor %}
-                                                {% if buckets|length > showMoreAfter %}
-                                                    <span class="show-more text-info text-center">more</span>
-                                                {% endif %}
-                                            </div>
-                                        {% endif %}
-                                        <button type="submit" class="btn btn-secondary pull-right btn-sm" role="button">Apply</button>
-                                    </div>
-                                </div>
-                            {% endfor %}
+                            {% include 'adventure/search_filters.html.twig' %}
                         </div>
                         <div class="col-9">
-                            <h2 id="search-results">{{ adventures|length }} adventures found</h2>
-                            <!-- BEGIN ADVENTURE LIST -->
-                            {% for adventure in adventures %}                            
-                                <div class="card mb-3">
-                                    <div class="card-block">
-                                        {% if adventure.thumbnailUrl %}
-                                            <img src="{{ adventure.thumbnailUrl }}" class="ml-1 pull-right" style="max-width: 120px; max-height: 140px;" />
-                                        {% endif %}
-                                        <h4 class="card-title">
-                                            <a href="{{ path('adventure_show', { 'slug': adventure.slug }) }}">
-                                                {{ adventure.title }}
-                                            </a>
-                                        </h4>
-                                        <!--h6 class="card-subtitle mb-2 text-muted">Search score: {{ adventure.score }}</h6-->
-                                        <p>{{ adventure.description|easyadmin_truncate(250) }}</p>
-                                        <div class="clearfix"></div>
-                                        <hr>
-                                        <!-- Quick look info -->
-                                        <div class="container-fluid row justify-content-center">
-                                            <div class="col-2 text-center">
-                                                <i class="fa fa-gear"></i>
-                                                <p class="text-muted mb-2">Edition</p>
-                                                <h6>{{adventure.edition}}</h6>
-                                            </div>
-                                            <div class="col-2 text-center">
-                                                <i class="fa fa-globe"></i>
-                                                <p class="text-muted mb-2">Setting</p>
-                                                <h6>{{adventure.setting}}</h6>
-                                            </div>
-                                            <div class="col-2 text-center">
-                                                <i class="fa fa-flag"></i>
-                                                <p class="text-muted mb-2">Starting Level</p>
-                                                <h6>
-                                                    {% if adventure.startingLevelRange %}
-                                                        {{ adventure.startingLevelRange }}
-                                                    {% else %}
-                                                        {{adventure.minStartingLevel}}-{{adventure.maxStartingLevel}}
-                                                    {% endif %}
-                                                </h6>
-                                            </div>
-                                            <div class="col-2 text-center">
-                                                <i class="fa fa-tree"></i>
-                                                <p class="text-muted mb-2">Environment</p>
-                                                <h6>{{adventure.environments|join(', ')}}</h6>
-                                            </div>
-                                            <div class="col-2 text-center">
-                                                <i class="fa fa-map"></i>
-                                                <p class="text-muted mb-2">Tactical Maps</p>
-                                                <h6>{{ adventure.tacticalMaps|bool2str }}</h6>
-                                            </div>
-                                        </div>
-                                        <!-- End quick look info -->
-                                    </div>
-                                </div>
-                            {% else %}
-                                <div class="alert alert-danger">We're sorry. Apparently there is no adventure matching your search :(</div>
-                            {% endfor %}
+                            {% include 'adventure/search_filter_tags.html.twig' %}
+                            {% include 'adventure/search_results.html.twig' %}
                         </div>
                     </div>
                 </form>

--- a/app/Resources/views/adventure/search_filter_tags.html.twig
+++ b/app/Resources/views/adventure/search_filter_tags.html.twig
@@ -1,19 +1,20 @@
 {% for fieldName, filter in searchFilter %}
     {% set values = filter['v']|default([]) %}
-    {% if values is not empty %}
+    {% if values is not iterable %}
+        {% set values = [values] %}
+    {% endif %}
+    {% if values|length > 0 %}
         {% set field = fields[fieldName] %}
-        {% if field.type == 'string' %}
-            {% for value in values %}
-                <span class="badge badge-primary filter-tag">
-                    {{ field.title }}: {{ value }}
-                    <span role="button" aria-label="Remove" data-field-name="{{ field.name }}" data-field-type="{{ field.type }}" data-value="{{ value }}" class="filter-remove">&times;</span>
-                </span>
-            {% endfor %}
-        {% elseif field.type == 'boolean' %}
+        {% for value in values %}
             <span class="badge badge-primary filter-tag">
-                {{ field.title }}: {{ values|bool2str }}
-                <span role="button" aria-label="Remove" data-field-name="{{ field.name }}" data-field-type="{{ field.type }}" data-value="{{ values }}" class="filter-remove">&times;</span>
+                {{ field.title }}:
+                {% if field.type == 'boolean' %}
+                    {{ value|bool2str }}
+                {% else %}
+                    {{ value }}
+                {% endif %}
+                <span role="button" aria-label="Remove" data-field-name="{{ field.name }}" data-field-type="{{ field.type }}" data-value="{{ value }}" class="filter-remove">&times;</span>
             </span>
-        {% endif %}
+        {% endfor %}
     {% endif %}
 {% endfor %}

--- a/app/Resources/views/adventure/search_filter_tags.html.twig
+++ b/app/Resources/views/adventure/search_filter_tags.html.twig
@@ -1,0 +1,19 @@
+{% for fieldName, filter in searchFilter %}
+    {% set values = filter['v']|default([]) %}
+    {% if values is not empty %}
+        {% set field = fields[fieldName] %}
+        {% if field.type == 'string' %}
+            {% for value in values %}
+                <span class="badge badge-primary filter-tag">
+                    {{ field.title }}: {{ value }}
+                    <span role="button" aria-label="Remove" data-field-name="{{ field.name }}" data-field-type="{{ field.type }}" data-value="{{ value }}" class="filter-remove">&times;</span>
+                </span>
+            {% endfor %}
+        {% elseif field.type == 'boolean' %}
+            <span class="badge badge-primary filter-tag">
+                {{ field.title }}: {{ values|bool2str }}
+                <span role="button" aria-label="Remove" data-field-name="{{ field.name }}" data-field-type="{{ field.type }}" data-value="{{ values }}" class="filter-remove">&times;</span>
+            </span>
+        {% endif %}
+    {% endif %}
+{% endfor %}

--- a/app/Resources/views/adventure/search_filters.html.twig
+++ b/app/Resources/views/adventure/search_filters.html.twig
@@ -105,4 +105,3 @@
 {{ macros.filter_field(fields['tacticalMaps'], stats, searchFilter) }}
 
 {{ macros.filter_field(fields['foundIn'], stats, searchFilter) }}
-{#{ macros.filter_field(fields['partOf'], stats, searchFilter) }#}

--- a/app/Resources/views/adventure/search_filters.html.twig
+++ b/app/Resources/views/adventure/search_filters.html.twig
@@ -1,0 +1,108 @@
+{% macro filter_checkbox(field, value, checked, count, hidden) %}
+    <div class="form-check{% if hidden %} d-none{% endif %}">
+        <label class="form-check-label">
+            <input class="form-check-input" type="checkbox" name="f[{{ field.name }}][v][]"
+                   value="{{ value }}"
+                   {% if checked %}checked{% endif %}
+            />
+            {{ value }}
+            <span class="badge-pill badge badge-default">{{ count }}</span>
+        </label>
+    </div>
+{% endmacro %}
+
+{% macro filter_field(field, stats, searchFilter) %}
+    {% import _self as macros %}
+    {% set filter = searchFilter[field.name]|default([]) %}
+    {% set show = true %} {# Currently, all filters are shown and expanded when the page is loaded #}
+    <div class="card mb-1 filter-card {{ show ? 'expanded' : '' }}" id="filter-{{ field.name }}">
+        <div class="card-block filter-title">
+            <h6 class="card-title">
+                {{ field.title }}
+                <i class="fa fa-fw fa-caret-up"></i>
+                <i class="fa fa-fw fa-caret-down"></i>
+            </h6>
+        </div>
+        <div class="card-block filter-content">
+            {% if field.description is not empty %}
+                <p class="card-text small">{{ field.description }}</p>
+            {% endif %}
+            {% if field.type == 'string' %}
+                <div class="filters">
+                    {% set buckets = stats['vals_' ~ field.name]['buckets'] %}
+                    {% set showMoreAfter = 5 %}
+                    {% set valuesUsed = [] %}
+                    {% for bucket in buckets %}
+                        {% set valuesUsed = valuesUsed|merge([bucket.key]) %}
+                        {{ macros.filter_checkbox(field, bucket.key, bucket.key in filter['v']|default([]), bucket.doc_count, loop.index0 >= showMoreAfter) }}
+                    {% endfor %}
+                    {% for value in filter['v']|default([]) if value != '' and value not in valuesUsed %}
+                        {{ macros.filter_checkbox(field, value, true, 0, false) }}
+                    {% endfor %}
+                    {% if buckets|length > showMoreAfter %}
+                        <span class="show-more text-info text-center">more</span>
+                    {% endif %}
+                </div>
+            {% elseif field.type == 'boolean' %}
+                <label class="form-check-label">
+                    <input class="form-check-input" type="radio"
+                           name="f[{{ field.name }}][v]" value=""
+                           {% if filter['v']|default('') == '' %}checked{% endif %}
+                    /> All
+                </label>
+                <label class="form-check-label">
+                    <input class="form-check-input" type="radio"
+                           name="f[{{ field.name }}][v]" value="1"
+                           {% if filter['v']|default('') == '1' %}checked{% endif %}
+                    /> Yes
+                </label>
+                <label class="form-check-label">
+                    <input class="form-check-input" type="radio"
+                           name="f[{{ field.name }}][v]" value="0"
+                           {% if filter['v']|default('') == '0' %}checked{% endif %}
+                    /> No
+                </label>
+            {% elseif field.type == 'integer' %}
+                <div class="row no-gutters mb-3">
+                    <div class="col">
+                        <input type="number" name="f[{{ field.name }}][v][min]" id="filter-{{ field.name }}-min"
+                               placeholder="min (inc.)" class="form-control form-control-sm"
+                               value="{{ filter['v']|default({min: ''})['min'] }}"
+                               title="min (inc.)"
+                        />
+                    </div>
+                    <div class="col">
+                        <input type="number" name="f[{{ field.name }}][v][max]" id="filter-{{ field.name }}-max"
+                               placeholder="max (inc.)" class="form-control form-control-sm"
+                               value="{{ filter['v']|default({max: ''})['max'] }}"
+                               title="max (inc.)"
+                        />
+                    </div>
+                </div>
+            {% endif %}
+            <button type="submit" class="btn btn-secondary pull-right btn-sm" role="button">Apply</button>
+        </div>
+    </div>
+{% endmacro %}
+{% import _self as macros %}
+{{ macros.filter_field(fields['publisher'], stats, searchFilter) }}
+{{ macros.filter_field(fields['setting'], stats, searchFilter) }}
+{{ macros.filter_field(fields['edition'], stats, searchFilter) }}
+
+{{ macros.filter_field(fields['environments'], stats, searchFilter) }}
+{{ macros.filter_field(fields['items'], stats, searchFilter) }}
+{{ macros.filter_field(fields['monsters'], stats, searchFilter) }}
+{{ macros.filter_field(fields['npcs'], stats, searchFilter) }}
+
+{{ macros.filter_field(fields['numPages'], stats, searchFilter) }}
+{{ macros.filter_field(fields['minStartingLevel'], stats, searchFilter) }}
+{{ macros.filter_field(fields['maxStartingLevel'], stats, searchFilter) }}
+{{ macros.filter_field(fields['startingLevelRange'], stats, searchFilter) }}
+
+{{ macros.filter_field(fields['soloable'], stats, searchFilter) }}
+{{ macros.filter_field(fields['pregeneratedCharacters'], stats, searchFilter) }}
+{{ macros.filter_field(fields['handouts'], stats, searchFilter) }}
+{{ macros.filter_field(fields['tacticalMaps'], stats, searchFilter) }}
+
+{{ macros.filter_field(fields['foundIn'], stats, searchFilter) }}
+{#{ macros.filter_field(fields['partOf'], stats, searchFilter) }#}

--- a/app/Resources/views/adventure/search_results.html.twig
+++ b/app/Resources/views/adventure/search_results.html.twig
@@ -1,0 +1,56 @@
+<h2 id="search-results">{{ adventures|length }} adventures found</h2>
+{% for adventure in adventures %}
+    <div class="card mb-3">
+        <div class="card-block">
+            {% if adventure.thumbnailUrl %}
+                <img src="{{ adventure.thumbnailUrl }}" class="ml-1 pull-right" style="max-width: 120px; max-height: 140px;" />
+            {% endif %}
+            <h4 class="card-title">
+                <a href="{{ path('adventure_show', { 'slug': adventure.slug }) }}">
+                    {{ adventure.title }}
+                </a>
+            </h4>
+            <!--h6 class="card-subtitle mb-2 text-muted">Search score: {{ adventure.score }}</h6-->
+            <p>{{ adventure.description|easyadmin_truncate(250) }}</p>
+            <div class="clearfix"></div>
+            <hr>
+            <!-- Quick look info -->
+            <div class="container-fluid row justify-content-center">
+                <div class="col-2 text-center">
+                    <i class="fa fa-gear"></i>
+                    <p class="text-muted mb-2">Edition</p>
+                    <h6>{{adventure.edition}}</h6>
+                </div>
+                <div class="col-2 text-center">
+                    <i class="fa fa-globe"></i>
+                    <p class="text-muted mb-2">Setting</p>
+                    <h6>{{adventure.setting}}</h6>
+                </div>
+                <div class="col-2 text-center">
+                    <i class="fa fa-flag"></i>
+                    <p class="text-muted mb-2">Starting Level</p>
+                    <h6>
+                        {% if adventure.startingLevelRange %}
+                            {{ adventure.startingLevelRange }}
+                        {% else %}
+                            {{adventure.minStartingLevel}}-{{adventure.maxStartingLevel}}
+                        {% endif %}
+                    </h6>
+                </div>
+                <div class="col-2 text-center">
+                    <i class="fa fa-tree"></i>
+                    <p class="text-muted mb-2">Environment</p>
+                    <h6>{{adventure.environments|join(', ')}}</h6>
+                </div>
+                <div class="col-2 text-center">
+                    <i class="fa fa-map"></i>
+                    <p class="text-muted mb-2">Tactical Maps</p>
+                    <h6>{{ adventure.tacticalMaps|bool2str }}</h6>
+                </div>
+            </div>
+            <!-- End quick look info -->
+        </div>
+    </div>
+{% else %}
+    <div class="alert alert-danger">We're sorry. Apparently there is no adventure matching your search :(</div>
+{% endfor %}

--- a/app/Resources/views/adventure/search_results.html.twig
+++ b/app/Resources/views/adventure/search_results.html.twig
@@ -48,7 +48,6 @@
                     <h6>{{ adventure.tacticalMaps|bool2str }}</h6>
                 </div>
             </div>
-            <!-- End quick look info -->
         </div>
     </div>
 {% else %}

--- a/app/Resources/views/adventure/show.html.twig
+++ b/app/Resources/views/adventure/show.html.twig
@@ -1,8 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% macro search_icon(fieldName, content) %}
-    {% set path = path('adventure_index', {('f[' ~ fieldName ~ '][v][]'): content}) %}
-
+    {% set path = path('adventure_index', {('f[' ~ fieldName ~ '][v]'): content}) %}
     <a href="{{ path }}" title="Search for similar adventures"><i class="fa fa-search"></i></a>
 {% endmacro %}
 
@@ -22,7 +21,10 @@
                     <div class="data-row">
                         <div class="col">
                             <div class="label">Written By</div>
-                            {{ adventure.authors|join(', ') }}
+                            {% for author in adventure.authors %}
+                                {{ author }}
+                                {{ macros.search_icon('authors', author) }}
+                            {% endfor %}
                         </div>
                         <div class="col">
                             <div class="label">Published By</div>

--- a/app/Resources/views/adventure/show.html.twig
+++ b/app/Resources/views/adventure/show.html.twig
@@ -1,5 +1,11 @@
 {% extends 'base.html.twig' %}
 
+{% macro search_icon(fieldName, content) %}
+    {% set path = path('adventure_index', {('f[' ~ fieldName ~ '][v][]'): content}) %}
+
+    <a href="{{ path }}" title="Search for similar adventures"><i class="fa fa-search"></i></a>
+{% endmacro %}
+
 {% block body %}
     {% import _self as macros %}
     <div class="container">
@@ -21,6 +27,7 @@
                         <div class="col">
                             <div class="label">Published By</div>
                             {{ adventure.publisher }}
+                            {{ macros.search_icon('publisher', adventure.publisher) }}
                         </div>
                         <div class="col">
                             <div class="label"># Of Pages</div>
@@ -37,22 +44,26 @@
                         <div class="col">
                             <div class="label">Found In</div>
                             {{ adventure.foundIn }}
+                            {{ macros.search_icon('foundIn', adventure.foundIn) }}
                         </div>
                     </div>
                     <div class="data-row">
                         <div class="col">
                             <div class="label">System / Edition</div>
                             {{ adventure.edition }}
+                            {{ macros.search_icon('edition', adventure.edition) }}
                         </div>
                         <div class="col">
                             <div class="label">Setting</div>
                             {{ adventure.setting }}
+                            {{ macros.search_icon('setting', adventure.setting) }}
                         </div>
                     </div>
                     <div class="data-row">
                         <div class="col">
                             <div class="label">Starting Level Range</div>
                             {{ adventure.startingLevelRange }}
+                            {{ macros.search_icon('startingLevelRange', adventure.startingLevelRange) }}
                         </div>
                         <div class="col">
                             <div class="label">Min. Starting Level</div>
@@ -67,18 +78,22 @@
                         <div class="col">
                             <div class="label">Handouts?</div>
                             {{ adventure.handouts|bool2str }}
+                            {{ macros.search_icon('handouts', adventure.handouts) }}
                         </div>
                         <div class="col">
                             <div class="label">Tactical Maps?</div>
                             {{ adventure.tacticalMaps|bool2str }}
+                            {{ macros.search_icon('tacticalMaps', adventure.tacticalMaps) }}
                         </div>
                         <div class="col">
                             <div class="label">Soloable?</div>
                             {{ adventure.soloable|bool2str }}
+                            {{ macros.search_icon('soloable', adventure.soloable) }}
                         </div>
                         <div class="col">
                             <div class="label">Includes Characters?</div>
                             {{ adventure.pregeneratedCharacters|bool2str }}
+                            {{ macros.search_icon('pregeneratedCharacters', adventure.pregeneratedCharacters) }}
                         </div>
                     </div>
                     <div class="data-row">
@@ -86,7 +101,7 @@
                             <div class="label">Notable Items</div>
                             <ul>
                                 {% for item in adventure.items %}
-                                    <li>{{ item }}</li>
+                                    <li>{{ item }} {{ macros.search_icon('items', item) }}</li>
                                 {% endfor %}
                             </ul>
                         </div>
@@ -96,7 +111,7 @@
                             <div class="label">Notable NPCs</div>
                             <ul>
                                 {% for npc in adventure.npcs %}
-                                    <li>{{ npc }}</li>
+                                    <li>{{ npc }} {{ macros.search_icon('npcs', npc) }}</li>
                                 {% endfor %}
                             </ul>
                         </div>
@@ -106,7 +121,7 @@
                             <div class="label">BBEG & Monsters</div>
                             <ul>
                                 {% for monster in adventure.monsters %}
-                                    <li>{{ monster }}</li>
+                                    <li>{{ monster }} {{ macros.search_icon('monsters', monster) }}</li>
                                 {% endfor %}
                             </ul>
                         </div>

--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -24,7 +24,7 @@
                         <input class="form-control" type="password" id="password" name="_password" />
                     </div>
 
-                    <button class="btn btn-primary" type="submit">Login</button>
+                    <button class="btn btn-primary" type="submit" role="button">Login</button>
                 </form>
             </div>
         </div>

--- a/app/Resources/webpack/sass/search.scss
+++ b/app/Resources/webpack/sass/search.scss
@@ -1,0 +1,41 @@
+.filter-card {
+  .filters .show-more {
+    display: block;
+    width: 100%;
+    cursor: pointer;
+  }
+  .filter-title {
+    cursor: pointer;
+  }
+
+  // Default state, filter not expanded
+  .fa-caret-up, .filter-content {
+    display: none;
+  }
+  .fa-caret-down {
+    display: inline;
+  }
+  .card-title {
+    margin: 0;
+  }
+
+  // Filter expanded
+  &.expanded {
+    .fa-caret-up {
+      display: inline;
+    }
+    .fa-caret-down {
+      display: none;
+    }
+    .filter-title {
+      padding-bottom: 0;
+    }
+    .filter-content {
+      padding-top: 0;
+      display: block;
+    }
+    .card-title {
+      margin-bottom: .75rem;
+    }
+  }
+}

--- a/app/Resources/webpack/sass/style.scss
+++ b/app/Resources/webpack/sass/style.scss
@@ -1,11 +1,6 @@
 @import './bootstrap.scss';
 @import 'adventure';
-
-.filter-card .filters .show-more {
-  display: block;
-  width: 100%;
-  cursor: pointer;
-}
+@import 'search';
 
 
 .selectize-control::before {

--- a/app/Resources/webpack/search.js
+++ b/app/Resources/webpack/search.js
@@ -1,5 +1,3 @@
-import Bloodhound from 'typeahead.js/dist/bloodhound';
-import noUiSlider from 'nouislider';
 import 'nouislider/distribute/nouislider.css';
 
 (function () {
@@ -8,103 +6,26 @@ import 'nouislider/distribute/nouislider.css';
         return;
     }
 
-    //$('.filter-slider').each(function () {
-    //    const min = $(this).data('min');
-    //    const max = $(this).data('max');
-    //    const fieldId = $(this).data('field-id');
-    //
-    //    const $min = $(`#filter-${fieldId}-min`);
-    //    const $max = $(`#filter-${fieldId}-max`);
-    //
-    //    const slider = noUiSlider.create($(this)[0], {
-    //        start: [$min.val(), $max.val()],
-    //        range: {
-    //            'min': [min],
-    //            'max': [max]
-    //        },
-    //        connect: true,
-    //        step: 1,
-    //        tooltips: true,
-    //        format: {
-    //            to: function (value) {
-    //                return parseInt(value);
-    //            },
-    //            from: function (value) {
-    //                return parseFloat(value)
-    //            }
-    //        }
-    //    });
-    //
-    //    slider.on('update', function( values, handle ) {
-    //        $min.val(values[0]);
-    //        $max.val(values[1]);
-    //    });
-    //});
-
-    $('#filter-add').click(function () {
-        const $filter = $("#filter-selection");
-        const val = $filter.val();
-        if (val === "") {
-            return;
+    $('.filter-card .filter-title').click(function () {
+        const $filter = $(this).parent('.filter-card');
+        const $filterEnabled = $(this).parent('.filter-enabled');
+        $filterEnabled.val($filter.toggleClass('expanded'));
+    });
+    $('.filter-tag .filter-remove').click(function () {
+        const fieldName = $(this).data('field-name');
+        const value = $(this).data('value');
+        const fieldType = $(this).data('field-type');
+        if (fieldType === 'string') {
+            $(`input[name^="f[${fieldName}][v]"][value="${value}"]`).prop('checked', false);
+        } else if (fieldType === 'boolean') {
+            $(`input[name^="f[${fieldName}][v]"][value=""]`).prop('checked', true);
         }
-        $filter.find('option:selected').remove();
-        const id = 'filter-' + val;
-        $('#' + id).removeClass('d-none');
-        document.getElementById(id).scrollIntoView();
-        $filter.prop("selectedIndex", 0);
-
-        $('#' + id + '-enabled').val('1');
+        $(this).parent('.filter-tag').remove();
+        $('#search-btn').click();
     });
 
     $('.filter-card .filters .show-more').on('click', function () {
         $(this).closest('.filters').find('.form-check').removeClass('d-none');
         $(this).remove();
     });
-    $(document).on('click', '.filter-card .filter-input button', function () {
-        const $inputContainer = $(this).closest('.filter-input');
-        const $clone = $inputContainer.clone();
-        const $clonedInput = $clone.find('.adv-search-input');
-        $clonedInput.val('');
-        $inputContainer.after($clone);
-        //initTypeahead($clonedInput);
-    });
-
-    const searchUrl = $page.data('search-url');
-
-    if ($('#advanced-search').hasClass('d-none')) {
-        $('#advanced-search').hide();
-    }
-    $('#toggle-adv-search').on('click', function () {
-        $('#advanced-search').removeClass('d-none').fadeToggle();
-    });
-
-    $('.adv-search-input').each(function () {
-        initTypeahead($(this));
-    });
-    function initTypeahead($element) {
-        const id = $element.data('id');
-        const content = new Bloodhound({
-            datumTokenizer: Bloodhound.tokenizers.whitespace,
-            queryTokenizer: Bloodhound.tokenizers.whitespace,
-            remote: {
-                url: searchUrl,
-                prepare: (query, settings) => {
-                    settings.url = searchUrl
-                        .replace(/__ID__/g, id)
-                        .replace(/__Q__/g, query);
-                    return settings;
-                },
-            },
-            sufficient: 20
-        });
-
-        $element.typeahead({
-            minLength: 0,
-            highlight: true
-        }, {
-            name: 'content',
-            source: content,
-            limit: 20
-        });
-    }
 })();

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -25,3 +25,7 @@ services:
         autowire: true
         tags:
             - { name: twig.extension }
+
+    app.field_provider:
+        class: AppBundle\Field\FieldProvider
+        autowire: true

--- a/src/AppBundle/Entity/AdventureDocument.php
+++ b/src/AppBundle/Entity/AdventureDocument.php
@@ -187,6 +187,10 @@ class AdventureDocument
         }
     }
 
+    /**
+     * @param Adventure $adventure
+     * @return static
+     */
     public static function fromAdventure(Adventure $adventure)
     {
         $info = [];

--- a/src/AppBundle/Exception/FieldDoesNotExistException.php
+++ b/src/AppBundle/Exception/FieldDoesNotExistException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace AppBundle\Exception;
+
+class FieldDoesNotExistException extends \RuntimeException
+{
+
+}

--- a/src/AppBundle/Field/Field.php
+++ b/src/AppBundle/Field/Field.php
@@ -1,0 +1,122 @@
+<?php
+
+
+namespace AppBundle\Field;
+
+class Field
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var bool
+     */
+    private $multiple;
+
+    /**
+     * @var bool
+     */
+    private $freetextSearchable;
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @var string
+     */
+    private $example;
+
+    public function __construct(string $name, string $type, bool $multiple, bool $freetextSearchable, string $title, string $description = null, string $example = null)
+    {
+        $this->name = $name;
+        $this->type = $type;
+        $this->multiple = $multiple;
+        $this->title = $title;
+        $this->description = $description;
+        $this->example = $example;
+        $this->freetextSearchable = $freetextSearchable;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMultiple(): bool
+    {
+        return $this->multiple;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFreetextSearchable(): bool
+    {
+        return $this->freetextSearchable;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExample()
+    {
+        return $this->example;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldNameForAggregation(): string
+    {
+        $field = $this->getName();
+        if (in_array($this->getType(), ['string', 'url'], true)) {
+            $field .= '.keyword';
+        }
+
+        return $field;
+    }
+}

--- a/src/AppBundle/Field/FieldProvider.php
+++ b/src/AppBundle/Field/FieldProvider.php
@@ -1,0 +1,194 @@
+<?php
+
+
+namespace AppBundle\Field;
+
+use AppBundle\Exception\FieldDoesNotExistException;
+use Doctrine\Common\Collections\ArrayCollection;
+
+class FieldProvider
+{
+    /**
+     * @var Field[]|ArrayCollection
+     */
+    private $fields;
+
+    public function __construct()
+    {
+        $this->fields = new ArrayCollection([
+            'title' => new Field(
+                'title',
+                'string',
+                false,
+                true,
+                'Title',
+                'The title of the adventure.'
+            ),
+            'description' => new Field(
+                'description',
+                'text',
+                false,
+                true,
+                'Description',
+                'Description of the adventure.'
+            ),
+            'authors' => new Field(
+                'authors',
+                'string',
+                true,
+                true,
+                'Authors',
+                'Names of people with writing or story credits on the module. Do not include editors or designers.'
+            ),
+            'edition' => new Field(
+                'edition',
+                'string',
+                false,
+                true,
+                'System / Edition',
+                'The system the game was designed for and the edition of that system if there is one.'
+            ),
+            'environments' => new Field(
+                'environments',
+                'string',
+                true,
+                true,
+                'Environments',
+                'The different types of environments the module will take place in.'
+            ),
+            'items' => new Field(
+                'items',
+                'string',
+                true,
+                true,
+                'Notable Items',
+                "The notable magic or non-magic items that are obtained in the module. Only include named items, don't include a +1 sword."),
+            'npcs' => new Field(
+                'npcs',
+                'string',
+                true,
+                true,
+                'NPCs',
+                'Names of notable NPCs'
+            ),
+            'publisher' => new Field(
+                'publisher',
+                'string',
+                false,
+                true,
+                'Publisher',
+                'Publisher of the adventure.'
+            ),
+            'setting' => new Field(
+                'setting',
+                'string',
+                false,
+                true,
+                'Setting',
+                'The narrative universe the module is set in.'
+            ),
+            'monsters' => new Field(
+                'monsters',
+                'string',
+                true,
+                true,
+                'Monsters',
+                'The various types of creatures featured in the module.'
+            ),
+
+
+            'numPages' => new Field(
+                'numPages',
+                'integer',
+                false,
+                false,
+                'Length (# of Pages)',
+                'Total page count of all written material in the module or at least primary string.'
+            ),
+            'minStartingLevel' => new Field(
+                'minStartingLevel',
+                'integer',
+                false,
+                false,
+                'Min. Starting Level',
+                'The minimum level characters are expected to be when taking part in the module.'
+            ),
+            'maxStartingLevel' => new Field(
+                'maxStartingLevel',
+                'integer',
+                false,
+                false,
+                'Max. Starting Level',
+                'The maximum level characters are expected to be when taking part in the module.'
+            ),
+            'startingLevelRange' => new Field(
+                'startingLevelRange',
+                'string',
+                false,
+                false,
+                'Level Range',
+                'In case no min. / max. starting levels but rather low/medium/high are given.'
+            ),
+
+
+            'soloable' => new Field(
+                'soloable',
+                'boolean',
+                false,
+                false,
+                'Suitable for Solo Play'
+            ),
+            'pregeneratedCharacters' => new Field(
+                'pregeneratedCharacters',
+                'boolean',
+                false,
+                false,
+                'Includes Pregenerated Characters'
+            ),
+            'handouts' => new Field(
+                'handouts',
+                'boolean',
+                false,
+                false,
+                'Handouts'
+            ),
+            'tacticalMaps' => new Field(
+                'tacticalMaps',
+                'boolean',
+                false,
+                false,
+                'Tactical Maps'
+            ),
+
+            'foundIn' => new Field(
+                'foundIn',
+                'string',
+                false,
+                true,
+                'Found In',
+                'The place the adventure can be found in.'
+            ),
+        ]);
+    }
+
+    /**
+     * @return Field[]|ArrayCollection
+     */
+    public function getFields(): ArrayCollection
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param $id
+     * @return Field
+     */
+    public function getField($id): Field
+    {
+        if (!$this->fields->containsKey($id)) {
+            throw new FieldDoesNotExistException(sprintf('Field with id "%s" does not exist!', $id));
+        }
+
+        return $this->fields->get($id);
+    }
+}

--- a/src/AppBundle/Form/AdventureType.php
+++ b/src/AppBundle/Form/AdventureType.php
@@ -30,7 +30,7 @@ class AdventureType extends AbstractType
     {
         $builder
             ->add('title', TextType::class, [
-                'help' => 'The title of the adventure. You can add more information in just a second.',
+                'help' => 'The title of the adventure.',
                 'required' => true,
             ])
             ->add('description', TextareaType::class, [


### PR DESCRIPTION
This adds the search filters once again (fixes #55).
This also introduces a new `FieldProvider` service, which I already used inside the `AdventureSearch` service. This avoids having to re-define available fields and field names all over the place. Eventually, this should be used everywhere where fields are accessed.