### PR TITLE
Make Google Analytics Code configurable

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -80,14 +80,14 @@
 
         <script src="{{ asset('assets/main.js') }}"></script>
         {% block javascripts %}{% endblock %}
-        {% if app.environment == 'prod' %}
+        {% if app.environment == 'prod' and google_analytics_code is not empty %}
             <script>
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
                 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-                ga('create', 'UA-97476648-1', 'auto');
+                ga('create', '{{ google_analytics_code }}', 'auto');
                 ga('send', 'pageview');
             </script>
         {% endif %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -40,6 +40,8 @@ twig:
     strict_variables: '%kernel.debug%'
     form_themes:
         - 'bootstrap_4_layout.html.twig'
+    globals:
+        google_analytics_code: '%google_analytics_code%'
 
 # Doctrine Configuration
 doctrine:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -8,8 +8,6 @@ parameters:
     database_user: root
     database_password: root
     database_driver: mysql
-    # You should uncomment this if you want to use pdo_sqlite
-    #database_path: '%kernel.root_dir%/../var/data/data.sqlite'
 
     mailer_transport: smtp
     mailer_host: 127.0.0.1
@@ -18,3 +16,5 @@ parameters:
 
     # A secret key that's used to generate certain security-related tokens
     secret: ThisTokenIsNotSoSecretChangeIt
+
+    google_analytics_code: ~


### PR DESCRIPTION
Fixes #63.
In your local installations, make sure to either execute `composer install` or copy `google_analytics_code: ~` into your `app/config/parameters.yml` file.