### PR TITLE
Fix freetext search

### DIFF
--- a/src/AppBundle/Service/AdventureSearch.php
+++ b/src/AppBundle/Service/AdventureSearch.php
@@ -341,7 +341,8 @@ class AdventureSearch
         $fields = $this->fieldProvider
             ->getFields()
             ->filter(function (Field $field) { return $field->isFreetextSearchable(); })
-            ->map(function (Field $field) { return $field->getName(); });
+            ->map(function (Field $field) { return $field->getName(); })
+            ->getValues();
 
         $terms = explode(',', $q);
         $qMatches = [];


### PR DESCRIPTION
I must've broken it recently. 
Convert ArrayCollection to the simple array ElasticSearch expects.