### PR TITLE
Fix the 'Array to String' conversion notice triggered when loading the RandomAdventures fixture

### DIFF
--- a/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
+++ b/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
@@ -78,7 +78,7 @@ class RandomAdventureData implements FixtureInterface, ContainerAwareInterface, 
                 ->setDescription($faker->realText(2000))
                 ->setNumPages($faker->numberBetween(1, 200))
                 ->setFoundIn($faker->catchPhrase)
-                ->setPartOf($faker->boolean() ? $faker->words(3) : null)
+                ->setPartOf($faker->boolean() ? $faker->catchPhrase : null)
                 ->setLink($faker->url)
                 ->setThumbnailUrl($faker->imageUrl(260, 300))
                 ->setSoloable($faker->boolean())


### PR DESCRIPTION
`->words()` actually returns an array. Should've simply used `->catchphrase in the first place`.