### PR TITLE
Use fuzziness for search, boost title field by 3

### DIFF
--- a/src/AppBundle/Field/Field.php
+++ b/src/AppBundle/Field/Field.php
@@ -26,6 +26,11 @@ class Field
     private $freetextSearchable;
 
     /**
+     * @var int
+     */
+    private $searchBoost;
+
+    /**
      * @var string
      */
     private $title;
@@ -40,7 +45,7 @@ class Field
      */
     private $example;
 
-    public function __construct(string $name, string $type, bool $multiple, bool $freetextSearchable, string $title, string $description = null, string $example = null)
+    public function __construct(string $name, string $type, bool $multiple, bool $freetextSearchable, string $title, string $description = null, int $searchBoost = 1, string $example = null)
     {
         $this->name = $name;
         $this->type = $type;
@@ -49,6 +54,7 @@ class Field
         $this->description = $description;
         $this->example = $example;
         $this->freetextSearchable = $freetextSearchable;
+        $this->searchBoost = $searchBoost;
     }
 
     /**
@@ -81,6 +87,14 @@ class Field
     public function isFreetextSearchable(): bool
     {
         return $this->freetextSearchable;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSearchBoost(): int
+    {
+        return $this->searchBoost;
     }
 
     /**

--- a/src/AppBundle/Field/FieldProvider.php
+++ b/src/AppBundle/Field/FieldProvider.php
@@ -22,7 +22,8 @@ class FieldProvider
                 false,
                 true,
                 'Title',
-                'The title of the adventure.'
+                'The title of the adventure.',
+                3
             ),
             'description' => new Field(
                 'description',

--- a/src/AppBundle/Service/AdventureSearch.php
+++ b/src/AppBundle/Service/AdventureSearch.php
@@ -342,7 +342,7 @@ class AdventureSearch
         $fields = $this->fieldProvider
             ->getFields()
             ->filter(function (Field $field) { return $field->isFreetextSearchable(); })
-            ->map(function (Field $field) { return $field->getName(); })
+            ->map(function (Field $field) { return $field->getName() . '^' . $field->getSearchBoost(); })
             ->getValues();
 
         $terms = explode(',', $q);
@@ -355,7 +355,7 @@ class AdventureSearch
                 'multi_match' => [
                     'query' => $term,
                     'fields' => $fields,
-                    'type' => 'phrase'
+                    'fuzziness' => 'AUTO'
                 ]
             ];
         }


### PR DESCRIPTION
This, for example, allows you to find adventures with a monster called "goblin" by searching for "golbins" or "goblins".
It also prioritizes search results where the terms are found inside the title.