### PR TITLE
Fix environment search links, fix field name for multiple search filters

### DIFF
--- a/app/Resources/views/adventure/show.html.twig
+++ b/app/Resources/views/adventure/show.html.twig
@@ -83,7 +83,7 @@
                             <div class="label">Environments</div>
                             {% for environment in adventure.environments %}
                                 {{ environment.name }}
-                                {{ macros.search_icon('environment', environment.name) }}
+                                {{ macros.search_icon('environments', environment.name) }}
                             {% endfor %}
                         </div>
                     </div>

--- a/src/AppBundle/Service/AdventureSearch.php
+++ b/src/AppBundle/Service/AdventureSearch.php
@@ -406,10 +406,11 @@ class AdventureSearch
                         ]
                     ];
                 } else {
+                    $fieldNameForSearch = $fieldName;
                     if ($field->getType() == 'string') {
-                        $fieldName .= '.keyword';
+                        $fieldNameForSearch .= '.keyword';
                     }
-                    $filterMatches[] = ['term' => [$fieldName => $value]];
+                    $filterMatches[] = ['term' => [$fieldNameForSearch => $value]];
                 }
             }
 


### PR DESCRIPTION
Use a local variable for the fieldname, otherwise the altered name is used in the next iteration of the loop.