### PR TITLE
Only log if critical error occurs, send critical errors via email

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -11,11 +11,26 @@ monolog:
     handlers:
         main:
             type: fingers_crossed
-            action_level: error
-            handler: nested
-        nested:
-            type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
+            action_level: critical
+            handler: grouped
+        grouped:
+            type:    group
+            members: [streamed, deduplicated]
+        streamed:
+            type:  stream
+            path:  '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
+        deduplicated:
+            type:    deduplication
+            timeout: 3600
+            handler: swift
+        swift:
+            type:       swift_mailer
+            from_email: 'error@adventurelookup.com'
+            to_email:   '%error_email_addresses%'
+            subject:    '[ADL Error] %%message%%'
+            level:      debug
+            formatter:  monolog.formatter.html
+            content_type: text/html
         console:
             type: console

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,3 +18,5 @@ parameters:
     secret: ThisTokenIsNotSoSecretChangeIt
 
     google_analytics_code: ~
+    # Email addresses to be notified if an error occurs
+    error_email_addresses: []


### PR DESCRIPTION
Proof of concept to send critical errors via email. This follows https://symfony.com/doc/current/logging/monolog_email.html.
It is configured to send the same error at most every 60 minutes.
The receiver email addresses must be set in `app/config/parameters.yml`:
```yml
    # ...
    error_email_addresses:
        - cmfcmf.flach@gmail.com
        - ...
```
Here is a screenshot of an actual email sent from dev.adventurelookup.com where I provoked a server error by temporarily requesting a non-existing service:
![image](https://user-images.githubusercontent.com/2145092/28976609-de480d58-793e-11e7-8b14-328d31341eee.png)