### PR TITLE
Force browser cache busting, check for duplicate entities on creation / edit

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <title>{% block title %}Adventure Lookup{% endblock %}</title>
-        <link rel="stylesheet" href="{{ asset('assets/styles.css') }}">
+        <link rel="stylesheet" href="{{ asset('assets/styles.css') }}?v=2">
         {% block stylesheets %}{% endblock %}
         <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('apple-touch-icon.png') }}">
         <link rel="icon" type="image/png" href="{{ asset('favicon-32x32.png') }}" sizes="32x32">
@@ -86,7 +86,7 @@
             </div>
         </footer>
 
-        <script src="{{ asset('assets/main.js') }}"></script>
+        <script src="{{ asset('assets/main.js') }}?v=2"></script>
         {% block javascripts %}{% endblock %}
         {% if app.environment == 'prod' and google_analytics_code is not empty %}
             <script>

--- a/app/Resources/webpack/adventure.js
+++ b/app/Resources/webpack/adventure.js
@@ -91,6 +91,32 @@ function debounce(func, wait, immediate) {
         let createNewItemCallback = false;
         if ($select.data('allow-add')) {
             createNewItemCallback = function(query, callback) {
+                // Check for existing selected options in select input
+                let existingOptionWithSameName = null;
+                const existingOptions = $select[0].selectize.options;
+                Object.keys(existingOptions).forEach(function (key) {
+                    let option = existingOptions[key];
+                    if (option.title.toLowerCase() === query.toLowerCase()) {
+                        existingOptionWithSameName = option;
+                    }
+                });
+                if (existingOptionWithSameName !== null) {
+                    callback();
+                    alert('An entity with the same name already exists.');
+                    return;
+                }
+                // Check for existing new entities on the page
+                $('input[id^="appbundle_adventure_' + fieldName + '-new_"][id$="_name"]').each(function () {
+                    if ($(this).val().toLowerCase() === query.toLowerCase()) {
+                        existingOptionWithSameName = $(this).val();
+                    }
+                });
+                if (existingOptionWithSameName !== null) {
+                    callback();
+                    alert('An entity with the same name is already going to be added to the adventure.');
+                    return;
+                }
+
                 const $modal = $('#newFieldContentModal');
                 const $modalForm = $modal.find('.modal-form');
                 const $modalAddBtn = $modal.find('#newFieldContentModal-add');

--- a/src/AppBundle/Form/MonsterType.php
+++ b/src/AppBundle/Form/MonsterType.php
@@ -27,6 +27,7 @@ class MonsterType extends AbstractType
                 'help' => 'Check this if the monster is a known named individual.'
             ])
             ->add('types', EntityType::class, [
+                'help' => 'Select all types that apply',
                 'choice_label' => 'name',
                 'required' => true,
                 'class' => MonsterTypeEntity::class,


### PR DESCRIPTION
This should help prevent problems described in #100.
It also forces browsers to use the new asset version (I have already worked on automatic asset versioning, but this is something for a later PR. For now, just append an incrementing version to the query string).
This requires you to run `npm run prod` to come into effect.