### PR TITLE
When checking for duplicated errors, only consider logs > warning

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -23,6 +23,7 @@ monolog:
         deduplicated:
             type:    deduplication
             timeout: 3600
+            level: warning
             handler: swift
         swift:
             type:       swift_mailer


### PR DESCRIPTION
Each user triggers a debug log message saying their token was read from
the session. Normally, this would trigger an email per user. By telling
the deduplication handler to only consider logs > warning, it avoids
sending an email for every user encountering the error.