### PR TITLE
Lazy-load images

### DIFF
--- a/app/Resources/views/adventure/search_results.html.twig
+++ b/app/Resources/views/adventure/search_results.html.twig
@@ -3,7 +3,7 @@
     <div class="card mb-3">
         <div class="card-block">
             {% if adventure.thumbnailUrl %}
-                <img src="{{ adventure.thumbnailUrl }}" class="ml-1 pull-right" style="max-width: 120px; max-height: 140px;" />
+                <img alt="Cover of {{ adventure.title }}" data-original="{{ adventure.thumbnailUrl }}" class="ml-1 pull-right" style="max-width: 120px; max-height: 140px;" />
             {% endif %}
             <h4 class="card-title">
                 <a href="{{ path('adventure_show', { 'slug': adventure.slug }) }}">

--- a/app/Resources/webpack/index.js
+++ b/app/Resources/webpack/index.js
@@ -8,6 +8,7 @@ import toastr from 'toastr/toastr';
 import 'toastr/toastr.scss';
 import "typeahead.js/dist/typeahead.jquery";
 import "typeahead.js-bootstrap4-css/typeaheadjs.css";
+import LazyLoad from "vanilla-lazyload/dist/lazyload";
 import './sass/style.scss';
 
 import './add-content.js';
@@ -32,3 +33,7 @@ toastr.options = {
     "showMethod": "fadeIn",
     "hideMethod": "fadeOut"
 };
+
+// Lazy-load images using
+// https://github.com/verlok/lazyload
+const myLazyLoad = new LazyLoad();

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typeahead.js": "^0.11.1",
     "typeahead.js-bootstrap4-css": "^1.0.0",
     "url-loader": "^0.5.8",
+    "vanilla-lazyload": "^8.0.3",
     "webpack": "^2.4.1"
   }
 }


### PR DESCRIPTION
Currently, the search page loads dozens of images for every request. 
This PR uses https://github.com/verlok/lazyload to load them only if they scroll into view.
Eventually, we should limit the number of search results and only load new ones if you scroll to the bottom, but this is something I didn't want to tackle yet.