### PR TITLE
Paginate activity log using the KnpPaginatorBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -20,6 +20,7 @@ class AppKernel extends Kernel
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle(),
             new DataDog\AuditBundle\DataDogAuditBundle(),
+            new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/Resources/views/audit/index.html.twig
+++ b/app/Resources/views/audit/index.html.twig
@@ -4,14 +4,16 @@
     <div class="container">
         <div class="row">
             <div class="col">
-                <h1 class="my-5">Recent activity</h1>
+                <h1 class="mt-5">Recent Activity</h1>
+                <small>Showing page {{ pagination.currentPageNumber }} of {{ pagination.pageCount }} pages.</small>
                 <table class="table">
                     <tbody>
-                    {% for log in logs %}
+                    {% for log in pagination %}
                         {{ audit(log) }}
                     {% endfor %}
                     </tbody>
                 </table>
+                {{ knp_pagination_render(pagination) }}
             </div>
         </div>
     </div>

--- a/app/Resources/webpack/sass/style.scss
+++ b/app/Resources/webpack/sass/style.scss
@@ -22,3 +22,7 @@
 .selectize-control.loading::before {
   opacity: 0.7;
 }
+
+.pagination {
+  @extend .justify-content-center;
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -113,6 +113,17 @@ stof_doctrine_extensions:
             blameable: true
             timestampable: true
 
+knp_paginator:
+    page_range: 5                # default page range used in pagination control
+    default_options:
+        page_name: page          # page query parameter name
+        sort_field_name: sort    # sort field query parameter name
+        sort_direction_name: dir # sort direction query parameter name
+        distinct: true           # ensure distinct results, useful when ORM queries are using GROUP BY statements
+    template:
+        pagination: 'KnpPaginatorBundle:Pagination:twitter_bootstrap_v4_pagination.html.twig'
+        sortable: 'KnpPaginatorBundle:Pagination:sortable_link.html.twig'
+
 # EasyAdminBundle
 # GitHub: https://github.com/javiereguiluz/EasyAdminBundle
 # Docs:   http://symfony.com/doc/current/bundles/EasyAdminBundle/index.html

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "fzaninotto/faker": "^1.6",
         "incenteev/composer-parameter-handler": "^2.0",
         "javiereguiluz/easyadmin-bundle": "^1.16",
+        "knplabs/knp-paginator-bundle": "^2.6",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "stof/doctrine-extensions-bundle": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c91bbf769695adb72de7d8004e756a7",
+    "content-hash": "68ea1c18bcdd560db93b8ba66a8a08c9",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1556,6 +1556,139 @@
                 "sql"
             ],
             "time": "2014-01-12T16:20:24+00:00"
+        },
+        {
+            "name": "knplabs/knp-components",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/knp-components.git",
+                "reference": "f98bcc6d348fbe863a224b468e11fb5e91e28f2a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/f98bcc6d348fbe863a224b468e11fb5e91e28f2a",
+                "reference": "f98bcc6d348fbe863a224b468e11fb5e91e28f2a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "doctrine/mongodb-odm": "~1.0@beta",
+                "doctrine/orm": "~2.4",
+                "doctrine/phpcr-odm": "~1.2",
+                "jackalope/jackalope-doctrine-dbal": "~1.2",
+                "phpunit/phpunit": "~4.2",
+                "ruflin/elastica": "~1.0",
+                "symfony/event-dispatcher": "~2.5"
+            },
+            "suggest": {
+                "doctrine/common": "to allow usage pagination with Doctrine ArrayCollection",
+                "doctrine/mongodb-odm": "to allow usage pagination with Doctrine ODM MongoDB",
+                "doctrine/orm": "to allow usage pagination with Doctrine ORM",
+                "doctrine/phpcr-odm": "to allow usage pagination with Doctrine ODM PHPCR",
+                "propel/propel1": "to allow usage pagination with Propel ORM",
+                "ruflin/Elastica": "to allow usage pagination with ElasticSearch Client",
+                "solarium/solarium": "to allow usage pagination with Solarium Client"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Knp\\Component": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://github.com/KnpLabs/knp-components/contributors"
+                }
+            ],
+            "description": "Knplabs component library",
+            "homepage": "http://github.com/KnpLabs/knp-components",
+            "keywords": [
+                "components",
+                "knp",
+                "knplabs",
+                "pager",
+                "paginator"
+            ],
+            "time": "2016-12-06T18:10:24+00:00"
+        },
+        {
+            "name": "knplabs/knp-paginator-bundle",
+            "version": "v2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/KnpPaginatorBundle.git",
+                "reference": "293abb6a2f1ae53ace5796d0ef3e5ae1b8f92371"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/KnpPaginatorBundle/zipball/293abb6a2f1ae53ace5796d0ef3e5ae1b8f92371",
+                "reference": "293abb6a2f1ae53ace5796d0ef3e5ae1b8f92371",
+                "shasum": ""
+            },
+            "require": {
+                "knplabs/knp-components": "~1.2",
+                "php": ">=5.3.3",
+                "symfony/framework-bundle": "~2.7|~3.0",
+                "twig/twig": "~1.12|~2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8",
+                "symfony/expression-language": "~2.7|~3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Knp\\Bundle\\PaginatorBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                },
+                {
+                    "name": "Symfony2 Community",
+                    "homepage": "http://github.com/KnpLabs/KnpPaginatorBundle/contributors"
+                }
+            ],
+            "description": "Paginator bundle for Symfony2 to automate pagination and simplify sorting and other features",
+            "homepage": "http://github.com/KnpLabs/KnpPaginatorBundle",
+            "keywords": [
+                "Symfony2",
+                "bundle",
+                "knp",
+                "knplabs",
+                "pager",
+                "pagination",
+                "paginator"
+            ],
+            "time": "2017-06-09T15:25:39+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/src/AppBundle/Controller/AuditController.php
+++ b/src/AppBundle/Controller/AuditController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use Doctrine\ORM\EntityManager;
+use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -19,6 +20,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AuditController extends Controller
 {
+    const LOGS_PER_PAGE = 50;
+
     /**
      * @Route("/audit", name="audit")
      * @Method("GET")
@@ -59,10 +62,16 @@ class AuditController extends Controller
                 ->setParameter('class', $filters['class']);
         }
 
-        $logs = $qb->getQuery()->execute();
+        $paginator  = $this->get('knp_paginator');
+        /** @var SlidingPagination $pagination */
+        $pagination = $paginator->paginate(
+            $qb->getQuery(),
+            $request->query->getInt('page', 1),
+            self::LOGS_PER_PAGE
+        );
 
         return $this->render('audit/index.html.twig', [
-            'logs' => $logs
+            'pagination' => $pagination
         ]);
     }
 


### PR DESCRIPTION
The log is really long and the page takes a while to load. This introduces a simple Bootstrap based pagination using the KnpPaginatorBundle. It also extends the `.pagination` class to center the pagination.