### PR TITLE
Delete adventures correctly

### DIFF
--- a/src/AppBundle/Listener/SearchIndexUpdater.php
+++ b/src/AppBundle/Listener/SearchIndexUpdater.php
@@ -10,6 +10,7 @@ use AppBundle\Service\ElasticSearch;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 
@@ -38,12 +39,18 @@ class SearchIndexUpdater implements EventSubscriber
      */
     private $typeName;
 
+    /**
+     * @var int[]
+     */
+    private $adventureIdsToRemove;
+
     public function __construct(ElasticSearch $elasticSearch)
     {
         $this->serializer = new AdventureSerializer();
         $this->client = $elasticSearch->getClient();
         $this->indexName = $elasticSearch->getIndexName();
         $this->typeName = $elasticSearch->getTypeName();
+        $this->adventureIdsToRemove = [];
     }
 
     /**
@@ -55,9 +62,11 @@ class SearchIndexUpdater implements EventSubscriber
     {
         return [
             'onFlush',
+            'preRemove',
             'postPersist',
             'postUpdate',
             'postRemove',
+            'postFlush',
         ];
     }
 
@@ -82,6 +91,20 @@ class SearchIndexUpdater implements EventSubscriber
         }
     }
 
+    /**
+     * Keep track of all ids of adventures being removed. We need to save them for later, because the id of
+     * a removed adventure is not available inside postRemove.
+     *
+     * @param LifecycleEventArgs $args
+     */
+    public function preRemove(LifecycleEventArgs $args)
+    {
+        $entity = $args->getEntity();
+        if ($entity instanceof Adventure) {
+            $this->adventureIdsToRemove[] = $entity->getId();
+        }
+    }
+
     public function postPersist(LifecycleEventArgs $args)
     {
         $this->handleInsertOrUpdate($args);
@@ -94,7 +117,24 @@ class SearchIndexUpdater implements EventSubscriber
 
     public function postRemove(LifecycleEventArgs $args)
     {
-        $this->handleRemoval($args);
+        $entity = $args->getEntity();
+        if ($entity instanceof Adventure) {
+            // Do nothing - if this is an adventure being deleted, Doctrine sets its id to null.
+            // We will delete the adventure in the postFlush listener - we saved the id in the preRemove listener.
+        } else {
+            // Don't delete the search index if the entity is not an adventure.
+            // Simply reindex the adventure instead.
+            $this->handleInsertOrUpdate($args);
+        }
+    }
+
+    public function postFlush(PostFlushEventArgs $args)
+    {
+        foreach ($this->adventureIdsToRemove as $adventureId) {
+            $this->deleteSearchIndexForAdventureId($adventureId);
+        }
+        // Make sure to reset the ids to remove in case another flush operation is following.
+        $this->adventureIdsToRemove = [];
     }
 
     private function handleInsertOrUpdate(LifecycleEventArgs $args)
@@ -107,18 +147,6 @@ class SearchIndexUpdater implements EventSubscriber
                 continue;
             }
             $this->updateSearchIndexForAdventure($adventure);
-        }
-    }
-
-    private function handleRemoval(LifecycleEventArgs $args)
-    {
-        $entity = $args->getEntity();
-        // Only delete the search index if the entity is an adventure.
-        // Otherwise reindex the adventure.
-        if ($entity instanceof Adventure) {
-            $this->deleteSearchIndexForAdventure($entity);
-        } else {
-            $this->handleInsertOrUpdate($args);
         }
     }
 
@@ -164,15 +192,15 @@ class SearchIndexUpdater implements EventSubscriber
      * Deletes the search index for the given adventure.
      * Fails silently if the index is already deleted.
      *
-     * @param Adventure $adventure
+     * @param int $adventureId
      */
-    private function deleteSearchIndexForAdventure(Adventure $adventure)
+    private function deleteSearchIndexForAdventureId(int $adventureId)
     {
         try {
             $this->client->delete([
                 'index' => $this->indexName,
                 'type' => $this->typeName,
-                'id' => $adventure->getId(),
+                'id' => $adventureId,
             ]);
         } catch (Missing404Exception $e) {
             // Apparently already deleted.


### PR DESCRIPTION
Currently, deleting an adventure triggers an error:
> Uncaught PHP Exception Elasticsearch\Common\Exceptions\InvalidArgumentException: "id cannot be null." at /var/www/new.adventurelookup.com/html/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Client.php line 1549

This is because Doctrine sets the id of an entity to `null` before calling the `postRemove` callback.
The solution is to fill an array of ids of adventures being removed in the `preRemove` callback and delete all adventures in the `postFlush` callback.