### PR TITLE
Disable CodeCov Bot comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,4 @@
 codecov:
+  comment: false
   ci:
     - !styleci.com

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,4 @@
+comment: false
 codecov:
-  comment: false
   ci:
     - !styleci.com


### PR DESCRIPTION
They are pretty spammy and since we don't have many tests yet, are pretty meaningless as well. Code coverage is still visible as part of the PR status checks: 
![image](https://user-images.githubusercontent.com/2145092/29081278-6a080a84-7c62-11e7-9d8e-88e8e26d3ffa.png)
