### PR TITLE
Change /adventures/new route to /adventure

### DIFF
--- a/src/AppBundle/Controller/AdventureController.php
+++ b/src/AppBundle/Controller/AdventureController.php
@@ -14,15 +14,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Adventure controller.
- *
- * @Route("adventures")
  */
 class AdventureController extends Controller
 {
     /**
      * Lists all adventure entities.
      *
-     * @Route("/", name="adventure_index")
+     * @Route("/adventures/", name="adventure_index")
      * @Method({"GET", "POST"})
      *
      * @param Request $request
@@ -49,7 +47,7 @@ class AdventureController extends Controller
     /**
      * Creates a new adventure entity.
      *
-     * @Route("/new", name="adventure_new")
+     * @Route("/adventure", name="adventure_new")
      * @Method({"GET", "POST"})
      *
      * @param Request $request
@@ -85,7 +83,7 @@ class AdventureController extends Controller
     /**
      * Finds and displays a adventure entity.
      *
-     * @Route("/{slug}", name="adventure_show")
+     * @Route("/adventures/{slug}", name="adventure_show")
      * @Method("GET")
      *
      * @param Adventure $adventure
@@ -106,7 +104,7 @@ class AdventureController extends Controller
     /**
      * Displays a form to edit an existing adventure entity.
      *
-     * @Route("/{id}/edit", name="adventure_edit")
+     * @Route("/adventures/{id}/edit", name="adventure_edit")
      * @Method({"GET", "POST"})
      *
      * @param Request $request
@@ -137,7 +135,7 @@ class AdventureController extends Controller
     /**
      * Deletes a adventure entity.
      *
-     * @Route("/{id}", name="adventure_delete")
+     * @Route("/adventures/{id}", name="adventure_delete")
      * @Method("DELETE")
      *
      * @param Request $request

--- a/src/AppBundle/Entity/MonsterType.php
+++ b/src/AppBundle/Entity/MonsterType.php
@@ -45,7 +45,7 @@ class MonsterType
 
     public function __construct()
     {
-        $this->types = new ArrayCollection();
+        $this->monsters = new ArrayCollection();
     }
 
     public function __toString(): string

--- a/tests/Browser/NewAdventureTest.php
+++ b/tests/Browser/NewAdventureTest.php
@@ -29,6 +29,8 @@ class NewAdventureTest extends BrowserTestCase
     const LINK = 'http://example.com';
     const THUMBNAIL_URL = 'http://lorempixel.com/130/160/';
 
+    const CREATE_ADVENTURE_PATH = '/adventure';
+
     /**
      * @dataProvider triggerValidationErrorProvider
      */
@@ -37,7 +39,7 @@ class NewAdventureTest extends BrowserTestCase
         $this->loadFixtures([UserData::class]);
         $session = $this->makeSession(true);
 
-        $this->visit($session, '/adventures/new');
+        $this->visit($session, self::CREATE_ADVENTURE_PATH);
 
         $page = $session->getPage();
         if (!$triggerValidationError) {
@@ -67,7 +69,7 @@ class NewAdventureTest extends BrowserTestCase
         $this->loadFixtures([UserData::class, RelatedEntitiesData::class]);
         $session = $this->makeSession(true);
 
-        $this->visit($session, '/adventures/new');
+        $this->visit($session, self::CREATE_ADVENTURE_PATH);
 
         if (!$triggerValidationError) {
             $this->fillField($session, 'title', self::TITLE);


### PR DESCRIPTION
Currently, if you create an adventure called 'new', the adventure's show route would be `/adventures/new`, which is the same as the route to create a new adventure. This would result in the adventure called 'new' not being possible to access. This PR changes the route to create new adventures to `/adventure`.
It also fixes a Typo I noticed.