### PR TITLE
Add assertions about max lengths of fields

### DIFF
--- a/src/AppBundle/Entity/Adventure.php
+++ b/src/AppBundle/Entity/Adventure.php
@@ -91,6 +91,7 @@ class Adventure
      *
      * @ORM\Column(name="title", type="string", length=255, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      * @Gedmo\Versioned()
      */
     private $title;
@@ -125,6 +126,7 @@ class Adventure
      * @var string
      *
      * @ORM\Column(type="string", length=255, nullable=true)
+     * @Assert\Length(max=255)
      * @Gedmo\Versioned()
      */
     private $startingLevelRange;
@@ -142,6 +144,7 @@ class Adventure
      * @var string
      *
      * @ORM\Column(type="string", length=255, nullable=true)
+     * @Assert\Length(max=255)
      * @Gedmo\Versioned()
      */
     private $foundIn;
@@ -150,6 +153,7 @@ class Adventure
      * @var string
      *
      * @ORM\Column(type="string", length=255, nullable=true)
+     * @Assert\Length(max=255)
      * @Gedmo\Versioned()
      */
     private $partOf;
@@ -158,6 +162,7 @@ class Adventure
      * @var string
      *
      * @ORM\Column(type="string", length=255, nullable=true)
+     * @Assert\Length(max=255)
      * @Assert\Url()
      * @Gedmo\Versioned()
      */
@@ -167,6 +172,7 @@ class Adventure
      * @var string
      *
      * @ORM\Column(type="string", length=255, nullable=true)
+     * @Assert\Length(max=255)
      * @Assert\Url()
      * @Gedmo\Versioned()
      */

--- a/src/AppBundle/Entity/Author.php
+++ b/src/AppBundle/Entity/Author.php
@@ -32,6 +32,7 @@ class Author implements HasAdventuresInterface
      *
      * @ORM\Column(name="name", type="string", length=255, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/ChangeRequest.php
+++ b/src/AppBundle/Entity/ChangeRequest.php
@@ -26,6 +26,7 @@ class ChangeRequest
      * @var string
      *
      * @ORM\Column(name="fieldName", type="string", length=255, nullable=true)
+     * @Assert\Length(max=255)
      */
     private $fieldName;
 

--- a/src/AppBundle/Entity/ChangeRequest.php
+++ b/src/AppBundle/Entity/ChangeRequest.php
@@ -4,6 +4,7 @@ namespace AppBundle\Entity;
 
 use Gedmo\Mapping\Annotation as Gedmo;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * ChangeRequest

--- a/src/AppBundle/Entity/Edition.php
+++ b/src/AppBundle/Entity/Edition.php
@@ -32,6 +32,7 @@ class Edition implements HasAdventuresInterface
      *
      * @ORM\Column(name="name", type="string", length=255, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/Environment.php
+++ b/src/AppBundle/Entity/Environment.php
@@ -32,6 +32,7 @@ class Environment implements HasAdventuresInterface
      *
      * @ORM\Column(name="name", type="string", length=255, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/Item.php
+++ b/src/AppBundle/Entity/Item.php
@@ -32,6 +32,7 @@ class Item implements HasAdventuresInterface
      *
      * @ORM\Column(name="name", type="string", length=255, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/Monster.php
+++ b/src/AppBundle/Entity/Monster.php
@@ -40,6 +40,7 @@ class Monster implements HasAdventuresInterface
      *
      * @ORM\Column(name="name", type="string", length=255)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/MonsterType.php
+++ b/src/AppBundle/Entity/MonsterType.php
@@ -5,12 +5,15 @@ namespace AppBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * MonsterType
  *
  * @ORM\Table(name="monster_type")
  * @ORM\Entity(repositoryClass="AppBundle\Repository\MonsterTypeRepository")
+ * @UniqueEntity("name")
  */
 class MonsterType
 {
@@ -32,6 +35,7 @@ class MonsterType
      * @var string
      *
      * @ORM\Column(name="name", type="string", length=255, unique=true)
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/Publisher.php
+++ b/src/AppBundle/Entity/Publisher.php
@@ -32,6 +32,7 @@ class Publisher implements HasAdventuresInterface
      *
      * @ORM\Column(name="name", type="string", length=255, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/Setting.php
+++ b/src/AppBundle/Entity/Setting.php
@@ -32,6 +32,7 @@ class Setting implements HasAdventuresInterface
      *
      * @ORM\Column(name="name", type="string", length=255, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     private $name;
 

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -25,6 +25,7 @@ class User implements AdvancedUserInterface, \Serializable
     /**
      * @ORM\Column(type="string", length=25, unique=true)
      * @Assert\NotBlank()
+     * @Assert\Length(max=25)
      */
     private $username;
 
@@ -40,6 +41,7 @@ class User implements AdvancedUserInterface, \Serializable
      * @ORM\Column(type="string", length=60, unique=true)
      * @Assert\NotBlank()
      * @Assert\Email()
+     * @Assert\Length(max=60)
      */
     private $email;
 

--- a/tests/AppBundle/Controller/RegistrationControllerTest.php
+++ b/tests/AppBundle/Controller/RegistrationControllerTest.php
@@ -75,6 +75,8 @@ class RegistrationControllerTest extends WebTestCase
     {
         $password = '12345678';
         $tooLongPassword = str_repeat('a', 73);
+        $tooLongUsername = str_repeat('a', 26);
+        $tooLongEmail = str_repeat('a', 49) . '@example.com';
 
         return [
             // Empty fields
@@ -83,6 +85,10 @@ class RegistrationControllerTest extends WebTestCase
             ['cmfcmf', 'foo.bar', $password, ['This value is not a valid email address.' => 1]],
             // Password too long
             ['cmfcmf', 'cmfcmf@example.com', $tooLongPassword, ['This value is too long.' => 1]],
+            // Username too long
+            [$tooLongUsername, 'cmfcmf@example.com', $password, ['This value is too long.' => 1]],
+            // Email too long
+            ['cmfcmf', $tooLongEmail, $password, ['This value is too long.' => 1]],
             // Duplicate username and email
             ['User #1', 'user1@example.com', $password, ['Username already taken' => 1, 'Email already taken' => 1]],
         ];


### PR DESCRIPTION
Currently, trying to create a user account with a long username or adding an adventure with a thumbnail url longer than 255 characters throws a 500 error, because the length is only enforced on the database and not on the forms. This PR adds a few `@Assert\Length` constraints to instead display a nice error message.

(for reference: coverage reports only appear because I branched of an old dev version)