### PR TITLE
Show own adventures with only resolved change requests

### DIFF
--- a/src/AppBundle/Controller/ProfileController.php
+++ b/src/AppBundle/Controller/ProfileController.php
@@ -6,6 +6,7 @@ use AppBundle\Entity\Adventure;
 use AppBundle\Entity\ChangeRequest;
 use AppBundle\Entity\User;
 use AppBundle\Form\ChangePasswordType;
+use Doctrine\ORM\Query\Expr;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -38,12 +39,8 @@ class ProfileController extends Controller
         // Sort them by adventures having a change request, then by title
         $adventures = $qb
             ->where($qb->expr()->eq('a.createdBy', ':username'))
-            ->leftJoin('a.changeRequests', 'c')
+            ->leftJoin('a.changeRequests', 'c', Expr\Join::WITH, 'c.resolved = false')
             ->addSelect('c')
-            ->andWhere($qb->expr()->orX(
-                $qb->expr()->eq('c.resolved', $qb->expr()->literal(false)),
-                $qb->expr()->isNull('c.id')
-            ))
             ->orderBy('c.id', 'DESC')
             ->addOrderBy('a.title', 'ASC')
             ->setParameter('username', $user->getUsername())

--- a/tests/AppBundle/Controller/ProfileControllerTest.php
+++ b/tests/AppBundle/Controller/ProfileControllerTest.php
@@ -155,6 +155,7 @@ class ProfileControllerTest extends WebTestCase
             ['your-adventure', false, -1],
             ['my-adventure-1', true, 1],
             ['my-adventure-2', true, 0],
+            ['my-adventure-3', true, 0]
         ];
     }
 

--- a/tests/Fixtures/ProfileTestData.php
+++ b/tests/Fixtures/ProfileTestData.php
@@ -44,9 +44,6 @@ class ProfileTestData extends AbstractFixture implements DependentFixtureInterfa
         $myAdventure = new Adventure();
         $myAdventure->setTitle('My Adventure 1');
 
-        $myAdventure2 = new Adventure();
-        $myAdventure2->setTitle('My Adventure 2');
-
         $myUnresolvedChangeRequest = new ChangeRequest();
         $myUnresolvedChangeRequest->setAdventure($myAdventure);
         $myUnresolvedChangeRequest->setResolved(false);
@@ -57,15 +54,30 @@ class ProfileTestData extends AbstractFixture implements DependentFixtureInterfa
         $myResolvedChangeRequest->setResolved(true);
         $myResolvedChangeRequest->setComment('My resolved change request');
 
+        $em->persist($myAdventure);
         $em->persist($myUnresolvedChangeRequest);
         $em->persist($myResolvedChangeRequest);
-        $em->persist($myAdventure);
-        $em->persist($myAdventure2);
         $this->addReference('my-adventure-1', $myAdventure);
-        $this->addReference('my-adventure-2', $myAdventure2);
         $this->addReference('my-unresolved-change-request', $myUnresolvedChangeRequest);
         $this->addReference('my-resolved-change-request', $myResolvedChangeRequest);
 
+        $myAdventure2 = new Adventure();
+        $myAdventure2->setTitle('My Adventure 2');
+
+        $em->persist($myAdventure2);
+        $this->addReference('my-adventure-2', $myAdventure2);
+
+        $myAdventure3 = new Adventure();
+        $myAdventure3->setTitle('My Adventure 3');
+
+        $myResolvedChangeRequest2 = new ChangeRequest();
+        $myResolvedChangeRequest2->setAdventure($myAdventure3);
+        $myResolvedChangeRequest2->setResolved(true);
+        $myResolvedChangeRequest2->setComment('My other resolved change request');
+
+        $em->persist($myAdventure3);
+        $em->persist($myResolvedChangeRequest2);
+        $this->addReference('my-adventure-3', $myAdventure3);
 
         $blameListener->setUserValue($this->getReference('user-2')->getUsername());
 


### PR DESCRIPTION
Currently, once an own adventure only has resolved change requests, it vanishes from the profile page. This PR addresses fixes the behaviour reported in #158.