### PR TITLE
Allow users to reset their passwords, configure Recaptcha bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -21,6 +21,7 @@ class AppKernel extends Kernel
             new JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle(),
             new DataDog\AuditBundle\DataDogAuditBundle(),
             new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
+            new EWZ\Bundle\RecaptchaBundle\EWZRecaptchaBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/DoctrineMigrations/Version20170814102259.php
+++ b/app/DoctrineMigrations/Version20170814102259.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170814102259 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE user ADD password_reset_token VARCHAR(180) DEFAULT NULL, ADD password_reset_requested_at DATETIME DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D6496B7BA4B6 ON user (password_reset_token)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_8D93D6496B7BA4B6 ON user');
+        $this->addSql('ALTER TABLE user DROP password_reset_token, DROP password_reset_requested_at');
+    }
+}

--- a/app/Resources/views/emails/reset_password.txt.twig
+++ b/app/Resources/views/emails/reset_password.txt.twig
@@ -1,0 +1,10 @@
+Hi {{ user.username }}!
+
+Someone requested a password reset for your account at {{ app.request.schemeAndHttpHost }}
+If it wasn't you, you can safely ignore this email.
+Otherwise, click or copy the following link to complete the reset process (it is valid for {{ ttl }} minutes):
+
+{{ url('do_password_reset', {token: user.passwordResetToken}) }}
+
+Regards,
+the AdventureLookup Team

--- a/app/Resources/views/password_reset/do_reset.html.twig
+++ b/app/Resources/views/password_reset/do_reset.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <div class="container">
+        <div class="row">
+            <div class="col">
+                <h1 class="mt-5">Set new account password</h1>
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary" type="submit" role="button">Save New Password</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/Resources/views/password_reset/request_reset.html.twig
+++ b/app/Resources/views/password_reset/request_reset.html.twig
@@ -1,0 +1,19 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <div class="container">
+        <div class="row">
+            <div class="col">
+                <h1 class="mt-5">Reset your account's password</h1>
+                <p class="mb-3">
+                    If you forgot your account's password, you can request a password reset link to be sent to your email address.
+                </p>
+
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary" type="submit" role="button">Send Password Reset Link</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -5,7 +5,11 @@
         <div class="row">
             <div class="col">
                 <h1 class="mt-5">Login</h1>
-                <p class="mb-3">If you haven't created an account yet, head over to <a href="{{ path('user_registration') }}">the registration page!</a></p>
+                <p class="mb-3">
+                    If you haven't created an account yet, head over to <a href="{{ path('user_registration') }}">the registration page!</a>
+                    <br>
+                    If you forgot your password, <a href="{{ path('request_password_reset') }}">go here to reset it</a>.
+                </p>
 
                 {% if error %}
                     <div class="alert alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -124,6 +124,10 @@ knp_paginator:
         pagination: 'KnpPaginatorBundle:Pagination:twitter_bootstrap_v4_pagination.html.twig'
         sortable: 'KnpPaginatorBundle:Pagination:sortable_link.html.twig'
 
+ewz_recaptcha:
+    public_key:  '%recaptcha_public_key%'
+    private_key: '%recaptcha_private_key%'
+
 # EasyAdminBundle
 # GitHub: https://github.com/javiereguiluz/EasyAdminBundle
 # Docs:   http://symfony.com/doc/current/bundles/EasyAdminBundle/index.html

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -32,3 +32,7 @@ monolog:
 
 #swiftmailer:
 #    delivery_addresses: ['me@example.com']
+
+
+ewz_recaptcha:
+    enabled: false

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,5 +18,9 @@ parameters:
     secret: ThisTokenIsNotSoSecretChangeIt
 
     google_analytics_code: ~
+
+    recaptcha_public_key: ~
+    recaptcha_private_key: ~
+
     # Email addresses to be notified if an error occurs
     error_email_addresses: []

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "doctrine/doctrine-migrations-bundle": "^1.0",
         "doctrine/orm": "^2.5",
         "elasticsearch/elasticsearch": "^5.2",
+        "excelwebzone/recaptcha-bundle": "^1.4",
         "fzaninotto/faker": "^1.6",
         "incenteev/composer-parameter-handler": "^2.0",
         "javiereguiluz/easyadmin-bundle": "^1.16",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "146da85fd54270b86eee2d10baefe054",
+    "content-hash": "a0434e8bc1f83408235aaef9898d1a94",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1137,6 +1137,53 @@
                 "search"
             ],
             "time": "2017-07-19T18:44:30+00:00"
+        },
+        {
+            "name": "excelwebzone/recaptcha-bundle",
+            "version": "v1.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/excelwebzone/EWZRecaptchaBundle.git",
+                "reference": "bff309088ce9bbe7cb8f154e2bb9376f0c7b41fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/excelwebzone/EWZRecaptchaBundle/zipball/bff309088ce9bbe7cb8f154e2bb9376f0c7b41fd",
+                "reference": "bff309088ce9bbe7cb8f154e2bb9376f0c7b41fd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "symfony/form": "^2.8 || ^3.0",
+                "symfony/framework-bundle": "^2.8 || ^3.0",
+                "symfony/validator": "^2.8 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.3"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "EWZ\\Bundle\\RecaptchaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael H. Arieli",
+                    "email": "excelwebzone@gmail.com",
+                    "homepage": "http://excelwebzone.com/"
+                }
+            ],
+            "description": "This bundle provides easy reCAPTCHA form field integration",
+            "homepage": "https://github.com/excelwebzone/EWZRecaptchaBundle",
+            "keywords": [
+                "recaptcha"
+            ],
+            "time": "2017-05-28T00:57:14+00:00"
         },
         {
             "name": "fzaninotto/faker",

--- a/src/AppBundle/Controller/PasswordResetController.php
+++ b/src/AppBundle/Controller/PasswordResetController.php
@@ -1,0 +1,145 @@
+<?php
+
+
+namespace AppBundle\Controller;
+
+use AppBundle\Entity\User;
+use AppBundle\Form\DoPasswordResetType;
+use AppBundle\Form\RequestPasswordResetType;
+use AppBundle\Security\TokenGenerator;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @Route("/reset-password")
+ */
+class PasswordResetController extends Controller
+{
+    /**
+     * How many minutes a password reset link is valid.
+     */
+    const PASSWORD_RESET_LINK_TTL = 60;
+
+    /**
+     * @Route("/request", name="request_password_reset")
+     * @Method({"GET", "POST"})
+     *
+     * @param Request $request
+     * @param UserInterface|null $user
+     * @return RedirectResponse|Response
+     */
+    public function requestPasswordResetAction(Request $request, UserInterface $user = null)
+    {
+        if ($user) {
+            return $this->redirectToRoute('profile');
+        }
+
+        $form = $this->createForm(RequestPasswordResetType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $email = $form->get('email')->getData();
+            $em = $this->getDoctrine()->getManager();
+            $user = $em->getRepository(User::class)->findOneBy(['email' => $email]);
+            if ($user instanceof User) {
+                $user
+                    ->setPasswordResetRequestedAt(new \DateTime())
+                    ->setPasswordResetToken(TokenGenerator::generateToken());
+                $em->flush();
+
+                $this->sendPasswordResetMail($user);
+            }
+
+            $this->addFlash('success', "If the provided email address is associated with a user account, an email with a password reset link was sent to it.");
+
+            return $this->redirectToRoute('login');
+        }
+
+        return $this->render('password_reset/request_reset.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @Route("/reset/{token}", name="do_password_reset")
+     * @Method({"GET", "POST"})
+     *
+     * @param Request $request
+     * @param string $token
+     * @param UserInterface $user
+     * @return RedirectResponse|Response
+     */
+    public function doPasswordResetAction(Request $request, string $token, UserInterface $user = null)
+    {
+        if ($user) {
+            return $this->redirectToRoute('profile');
+        }
+
+        $em = $this->getDoctrine()->getManager();
+        $user = $em->getRepository(User::class)->findOneBy(['passwordResetToken' => $token]);
+        if (!$user) {
+            $this->addFlash('danger', "Invalid password reset token. Maybe you didn't copy the whole link?");
+
+            return $this->redirectToRoute('request_password_reset');
+        }
+
+        $passwordResetRequestedAt = $user->getPasswordResetRequestedAt();
+        if (!$passwordResetRequestedAt instanceof \DateTimeInterface) {
+            $this->addFlash('danger', "Something went wrong. Please try to request a new password reset link.");
+
+            return $this->redirectToRoute('request_password_reset');
+        }
+
+        if (time() > $passwordResetRequestedAt->getTimestamp() + self::PASSWORD_RESET_LINK_TTL * 60) {
+            $this->addFlash('danger', "This password reset link is no longer valid. Please generate a new one if you still need to reset your password.");
+
+            return $this->redirectToRoute('request_password_reset');
+        }
+
+        $form = $this->createForm(DoPasswordResetType::class, $user);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $user = $form->getData();
+            $em = $this->getDoctrine()->getManager();
+            $user
+                ->setPasswordResetRequestedAt(null)
+                ->setPasswordResetToken(null);
+            $em->flush();
+
+            $this->addFlash('success', "Your password was changed. You can now login using your username and password");
+
+            return $this->redirectToRoute('login');
+        }
+
+        return $this->render('password_reset/do_reset.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @param User $user
+     */
+    private function sendPasswordResetMail(User $user)
+    {
+        $mailer = $this->get('mailer');
+        $message = (new \Swift_Message('Hello Email'))
+            ->setFrom('noreply@adventurelookup.com')
+            ->setTo($user->getEmail())
+            ->setSubject('Password Reset for AdventureLookup')
+            ->setBody(
+                $this->renderView(
+                    'emails/reset_password.txt.twig',
+                    ['user' => $user, 'ttl' => self::PASSWORD_RESET_LINK_TTL]
+                ),
+                'text/plain'
+            );
+
+        $mailer->send($message);
+    }
+}

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -51,6 +51,20 @@ class User implements AdvancedUserInterface, \Serializable
     private $isActive;
 
     /**
+     * @ORM\Column(type="string", length=180, unique=true, nullable=true)
+     *
+     * @var string|null
+     */
+    private $passwordResetToken;
+
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     *
+     * @var \DateTimeInterface|null
+     */
+    private $passwordResetRequestedAt;
+
+    /**
      * @var string[]
      *
      * @ORM\Column(name="roles", type="simple_array")
@@ -96,6 +110,46 @@ class User implements AdvancedUserInterface, \Serializable
     public function getRoles()
     {
         return $this->roles;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPasswordResetToken()
+    {
+        return $this->passwordResetToken;
+    }
+
+    /**
+     * @param string|null $passwordResetToken
+     *
+     * @return User
+     */
+    public function setPasswordResetToken($passwordResetToken)
+    {
+        $this->passwordResetToken = $passwordResetToken;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTimeInterface|null
+     */
+    public function getPasswordResetRequestedAt()
+    {
+        return $this->passwordResetRequestedAt;
+    }
+
+    /**
+     * @param \DateTimeInterface|null $passwordResetRequestedAt
+     *
+     * @return User
+     */
+    public function setPasswordResetRequestedAt($passwordResetRequestedAt)
+    {
+        $this->passwordResetRequestedAt = $passwordResetRequestedAt;
+
+        return $this;
     }
 
     public function eraseCredentials()

--- a/src/AppBundle/Form/DoPasswordResetType.php
+++ b/src/AppBundle/Form/DoPasswordResetType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class DoPasswordResetType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('plainPassword', RepeatedType::class, [
+            'type' => PasswordType::class,
+            'first_options'  => ['label' => 'New Password'],
+            'second_options' => ['label' => 'Repeat New Password'],
+            'constraints' => new NotBlank()
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class
+        ]);
+    }
+}

--- a/src/AppBundle/Form/RequestPasswordResetType.php
+++ b/src/AppBundle/Form/RequestPasswordResetType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\Form;
+
+use EWZ\Bundle\RecaptchaBundle\Form\Type\EWZRecaptchaType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+use EWZ\Bundle\RecaptchaBundle\Validator\Constraints\IsTrue as RecaptchaTrue;
+
+class RequestPasswordResetType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('email', EmailType::class, [
+                'required' => true,
+                'help' => 'The email address you used to create your account.'
+            ])
+            ->add('captcha', EWZRecaptchaType::class, [
+                'constraints' => [
+                    new RecaptchaTrue()
+                ]
+            ]);
+    }
+}

--- a/src/AppBundle/Form/UserType.php
+++ b/src/AppBundle/Form/UserType.php
@@ -23,7 +23,7 @@ class UserType extends AbstractType
                 'type' => PasswordType::class,
                 'first_options'  => ['label' => 'Password'],
                 'second_options' => ['label' => 'Repeat Password'],
-                'constraints' => new NotBlank()
+                'constraints' => [new NotBlank()]
             ])
         ;
     }

--- a/src/AppBundle/Security/TokenGenerator.php
+++ b/src/AppBundle/Security/TokenGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace AppBundle\Security;
+
+/**
+ * Based on the TokenGenerator class of the FOSUserBundle.
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Util/TokenGenerator.php
+ */
+class TokenGenerator
+{
+    public static function generateToken()
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+}

--- a/tests/AppBundle/Controller/PasswordResetControllerTest.php
+++ b/tests/AppBundle/Controller/PasswordResetControllerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\AppBundle\Controller;
+
+use AppBundle\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\SwiftmailerBundle\DataCollector\MessageDataCollector;
+use Tests\Fixtures\UserData;
+use Tests\WebTestCase;
+
+class PasswordResetControllerTest extends WebTestCase
+{
+    const USERNAME = 'User #1';
+
+    const NEW_PASSWORD = 'new-password';
+
+    const VALID_RESET_TOKEN = 'reset-token';
+
+    const INVALID_RESET_TOKEN = 'foo-bar';
+
+    public function testFullWorkflow()
+    {
+        $this->loadFixtures([UserData::class]);
+        $session = $this->makeSession();
+
+        $session->visit('/login');
+        $page = $session->getPage();
+        $page->findLink('go here to reset it')->click();
+
+        $page->fillField('request_password_reset_email', 'user1@example.com');
+
+        // The following block temporarily enables the Profiler and disables following redirects.
+        // This is necessary to check whether or not an email was sent.
+        /** @var Client $client */
+        $client = $session->getDriver()->getClient();
+        $client->enableProfiler();
+        $client->followRedirects(false);
+        $page->findButton('Send Password Reset Link')->click();
+        $resetPasswordUrl = $this->verifyPasswordResetEmailSent($client);
+        $client->followRedirect();
+        $client->followRedirects(true);
+
+        $this->assertTrue($page->hasContent('email with a password reset link was sent'));
+
+        $session->visit($resetPasswordUrl);
+        $page->fillField('do_password_reset_plainPassword_first', self::NEW_PASSWORD);
+        $page->fillField('do_password_reset_plainPassword_second', self::NEW_PASSWORD);
+        $page->findButton('Save New Password')->click();
+
+        $this->assertTrue($page->hasContent('Your password was changed'));
+        $page->fillField('username', self::USERNAME);
+        $page->fillField('password', self::NEW_PASSWORD);
+        $page->findButton('Login')->click();
+
+        $session->visit('/profile');
+        $this->assertTrue($page->hasContent('Welcome, @' . self::USERNAME));
+    }
+
+    /**
+     * @param Client $client
+     * @return string The password reset link extracted from the email
+     */
+    private function verifyPasswordResetEmailSent(Client $client): string
+    {
+        /** @var MessageDataCollector $mailCollector */
+        $mailCollector = $client->getProfile()->getCollector('swiftmailer');
+
+        $this->assertEquals(1, $mailCollector->getMessageCount());
+
+        $collectedMessages = $mailCollector->getMessages();
+        /** @var \Swift_Message $message */
+        $message = $collectedMessages[0];
+
+        // Asserting email data
+        $this->assertInstanceOf('Swift_Message', $message);
+        $this->assertContains('Password Reset', $message->getSubject());
+        $this->assertEquals('noreply@adventurelookup.com', key($message->getFrom()));
+        $this->assertEquals('user1@example.com', key($message->getTo()));
+        $this->assertContains(
+            self::USERNAME,
+            $message->getBody()
+        );
+
+        preg_match('#http://localhost/reset-password/reset/[\w-_]{40,}#', $message->getBody(), $matches);
+        $this->assertCount(1, $matches);
+
+        return $matches[0];
+    }
+
+    public function testRedirectIfLoggedIn()
+    {
+        $this->loadFixtures([UserData::class]);
+        $session = $this->makeSession(true);
+
+        $session->visit('/reset-password/request');
+        $this->assertPath($session, '/profile/');
+        $session->visit('/reset-password/reset/foo-bar');
+        $this->assertPath($session, '/profile/');
+    }
+
+    public function testIfResetTokenIsValidated()
+    {
+        $this->loadFixtures([]);
+        $session = $this->makeSession();
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $user = new User();
+        $user->setUsername("User 1");
+        $user->setEmail("user1@example.com");
+        $user->setRoles(['ROLE_USER']);
+        $user->setPlainPassword("user1");
+        $user->setIsActive(true);
+        $user->setPasswordResetToken(self::VALID_RESET_TOKEN);
+        $em->persist($user);
+        $em->flush();
+
+        $session->visit('/reset-password/reset/' . self::INVALID_RESET_TOKEN);
+        $this->assertPath($session, '/reset-password/request');
+        $this->assertTrue($session->getPage()->hasContent('Invalid password reset token'));
+
+        $session->visit('/reset-password/reset/' . self::VALID_RESET_TOKEN);
+        $this->assertPath($session, '/reset-password/request');
+        $this->assertContains('try to request a new password reset link', $session->getPage()->getContent());
+
+        $user->setPasswordResetRequestedAt(new \DateTime('61 minutes ago'));
+        $em->flush();
+        $session->visit('/reset-password/reset/' . self::VALID_RESET_TOKEN);
+        $this->assertPath($session, '/reset-password/request');
+        $this->assertContains('reset link is no longer valid', $session->getPage()->getContent());
+
+        $user->setPasswordResetRequestedAt(new \DateTime('55 minutes ago'));
+        $em->flush();
+        $session->visit('/reset-password/reset/' . self::VALID_RESET_TOKEN);
+        $this->assertContains('new account password', $session->getPage()->getContent());
+    }
+}


### PR DESCRIPTION
This allows users to reset their passwords by providing their email address. and submitting a Google Recaptcha. The captcha is disabled in dev and test environments. The email is simply plaintext for now.
refs #31 
