### PR TITLE
Add curator remarks to change requests

### DIFF
--- a/app/DoctrineMigrations/Version20170814122644.php
+++ b/app/DoctrineMigrations/Version20170814122644.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170814122644 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE change_request ADD curator_remarks VARCHAR(512) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE change_request DROP curator_remarks');
+    }
+}

--- a/app/Resources/views/change_request/show.html.twig
+++ b/app/Resources/views/change_request/show.html.twig
@@ -19,6 +19,7 @@
                     {% else %}
                         General change request
                     {% endif %}
+                    <small>by @{{ changeRequest.createdBy }}.</small>
                     {% if changeRequest.resolved %}
                         <small>RESOLVED</small>
                     {% endif %}
@@ -26,14 +27,29 @@
                 <small>{{ changeRequest.createdAt|time_diff }}</small>
             </div>
             <p class="mb-1">{{ changeRequest.comment|nl2br }}</p>
+            {% if changeRequest.curatorRemarks is not empty %}
+                <p class="mb-1">Curator remarks: {{ changeRequest.curatorRemarks }}</p>
+            {% endif %}
             <div class="d-flex w-100 justify-content-between">
-                <small>Proposed by @{{ changeRequest.createdBy }}.</small>
                 {% if is_granted('toggle_resolved', changeRequest) %}
                     <form action="{{ path('changerequest_resolve', {id: changeRequest.id}) }}" method="post">
                         <div>
                             <input type="hidden" name="_csrf_token" value="{{ csrf_token('resolveChangeRequest') }}" />
                             <input type="hidden" name="resolve" value="{{ not changeRequest.resolved }}" />
-                            <input type="submit" value="{% if changeRequest.resolved %}Unresolve{% else %}Resolve{% endif %}" class="btn-link" role="button" />
+                            <input type="submit" value="{% if changeRequest.resolved %}Unresolve{% else %}Resolve{% endif %}" class="btn btn-sm btn-primary" role="button" />
+                        </div>
+                    </form>
+                {% endif %}
+                {% if is_granted('edit_curator_remarks', changeRequest) %}
+                    <form action="{{ path('changerequest_curator_remarks', {id: changeRequest.id}) }}" method="post" class="w-100 ml-3">
+                        <div>
+                            <input type="hidden" name="_csrf_token" value="{{ csrf_token('curatorRemarksForChangeRequest') }}" />
+                            <div class="input-group input-group-sm">
+                                <input type="text" class="form-control" placeholder="Publicly comment on this change request (i.e. if invalid)" name="remarks" maxlength="512" value="{{ changeRequest.curatorRemarks }}">
+                                <span class="input-group-btn">
+                                    <button class="btn btn-secondary" type="submit" role="button">Update Remarks</button>
+                                </span>
+                            </div>
                         </div>
                     </form>
                 {% endif %}

--- a/src/AppBundle/Entity/ChangeRequest.php
+++ b/src/AppBundle/Entity/ChangeRequest.php
@@ -39,6 +39,13 @@ class ChangeRequest
     private $comment;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=512, nullable=true)
+     */
+    private $curatorRemarks;
+
+    /**
      * @var boolean
      *
      * @ORM\Column(name="resolved", type="boolean", nullable=false)
@@ -150,6 +157,25 @@ class ChangeRequest
     public function getComment()
     {
         return $this->comment;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCuratorRemarks()
+    {
+        return $this->curatorRemarks;
+    }
+
+    /**
+     * @param string $curatorRemarks
+     *
+     * @return ChangeRequest
+     */
+    public function setCuratorRemarks($curatorRemarks)
+    {
+        $this->curatorRemarks = $curatorRemarks;
+        return $this;
     }
 
     /**

--- a/src/AppBundle/Security/ChangeRequestVoter.php
+++ b/src/AppBundle/Security/ChangeRequestVoter.php
@@ -13,6 +13,7 @@ class ChangeRequestVoter extends Voter
 {
     const CREATE = 'create';
     const TOGGLE_RESOLVED = 'toggle_resolved';
+    const EDIT_CURATOR_REMARKS = 'edit_curator_remarks';
 
     /**
      * @var AccessDecisionManager
@@ -34,7 +35,7 @@ class ChangeRequestVoter extends Voter
      */
     protected function supports($attribute, $subject)
     {
-        if (!in_array($attribute, [self::CREATE, self::TOGGLE_RESOLVED])) {
+        if (!in_array($attribute, [self::CREATE, self::TOGGLE_RESOLVED, self::EDIT_CURATOR_REMARKS])) {
             return false;
         }
         if (!($subject instanceof ChangeRequest)) {
@@ -60,7 +61,8 @@ class ChangeRequestVoter extends Voter
             case self::CREATE:
                 return $this->canCreate($subject, $token);
             case self::TOGGLE_RESOLVED:
-                return $this->canToggleResolved($subject, $token);
+            case self::EDIT_CURATOR_REMARKS:
+                return $this->canToggleResolvedAndEditCuratorRemarks($subject, $token);
         }
 
         throw new \LogicException('This code should not be reached!');
@@ -85,13 +87,13 @@ class ChangeRequestVoter extends Voter
     }
 
     /**
-     * Only curators and the adventure's author can toggle the resolved status of a change request.
+     * Only curators and the adventure's author can toggle the resolved status or edit the curator remarks of a change request.
      *
      * @param ChangeRequest $changeRequest
      * @param TokenInterface $token
      * @return bool
      */
-    private function canToggleResolved(ChangeRequest $changeRequest, TokenInterface $token)
+    private function canToggleResolvedAndEditCuratorRemarks(ChangeRequest $changeRequest, TokenInterface $token)
     {
         $user = $token->getUser();
         if (!($user instanceof User)) {


### PR DESCRIPTION
Curators and an adventure's author can now add a remark to change requests, i.e. when they are invalid. The remark is visible to anyone who sees the change request.
refs #167 
