### PR TITLE
Paginate adventure search using ElasticSearch from/size parameters

### DIFF
--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -11,7 +11,7 @@
                 {% endif %}
                 <p>Find adventures fitting your search term!</p>
                 <div class="clearfix"></div>
-                <form method="post" action="{{ url('adventure_index') }}{##search-results#}">
+                <form method="post" action="{{ url('adventure_index') }}" id="search-form">
                     <div class="input-group input-group-lg">
                         <input class="form-control" name="q" type="text" value="{{ q }}" placeholder="goblins, mountains, ..." />
                         <span class="input-group-btn">

--- a/app/Resources/views/adventure/search_results.html.twig
+++ b/app/Resources/views/adventure/search_results.html.twig
@@ -1,59 +1,65 @@
-<h2 id="search-results">{{ adventures|length }} adventures found</h2>
-{% for adventure in adventures %}
-    <div class="card mb-3">
-        <div class="card-block">
-            {% if adventure.thumbnailUrl %}
-                <img alt="Cover of {{ adventure.title }}" data-original="{{ adventure.thumbnailUrl }}" class="ml-sm-1 float-sm-right" style="max-width: 120px; max-height: 140px;" />
-            {% endif %}
-            <h4 class="card-title">
-                <a href="{{ path('adventure_show', { 'slug': adventure.slug }) }}">
-                    {{ adventure.title }}
-                </a>
-            </h4>
-            <!--h6 class="card-subtitle mb-2 text-muted">Search score: {{ adventure.score }}</h6-->
-            <p>{{ adventure.description|easyadmin_truncate(250) }}</p>
-            <div class="clearfix"></div>
-            <hr>
-            <!-- Quick look info -->
-            <div class="container-fluid row justify-content-center">
-                <div class="col-6 col-sm text-center">
-                    <i class="fa fa-gear"></i>
-                    <p class="text-muted mb-2">Edition</p>
-                    <h6>{{adventure.edition}}</h6>
-                </div>
-                <div class="col-6 col-sm text-center">
-                    <i class="fa fa-globe"></i>
-                    <p class="text-muted mb-2">Setting</p>
-                    <h6>{{adventure.setting}}</h6>
-                </div>
-                <div class="col-6 col-sm text-center">
-                    <i class="fa fa-flag"></i>
-                    <p class="text-muted mb-2">Starting Level</p>
-                    <h6>
-                        {% if adventure.minStartingLevel is not null and adventure.maxStartingLevel is not null %}
-                            {% if adventure.minStartingLevel == adventure.maxStartingLevel %}
-                                {{ adventure.minStartingLevel }}
+<h2 >{{ totalNumberOfResults }} {{ totalNumberOfResults == 1 ? 'adventure' : 'adventures' }} found</h2>
+<div id="search-results">
+    {% for adventure in adventures %}
+        <div class="card mb-3">
+            <div class="card-block">
+                {% if adventure.thumbnailUrl %}
+                    <img alt="Cover of {{ adventure.title }}" data-original="{{ adventure.thumbnailUrl }}" class="ml-sm-1 float-sm-right" style="max-width: 120px; max-height: 140px;" />
+                {% endif %}
+                <h4 class="card-title">
+                    <a href="{{ path('adventure_show', { 'slug': adventure.slug }) }}">
+                        {{ adventure.title }}
+                    </a>
+                </h4>
+                <!--h6 class="card-subtitle mb-2 text-muted">Search score: {{ adventure.score }}</h6-->
+                <p>{{ adventure.description|easyadmin_truncate(250) }}</p>
+                <div class="clearfix"></div>
+                <hr>
+                <!-- Quick look info -->
+                <div class="container-fluid row justify-content-center">
+                    <div class="col-6 col-sm text-center">
+                        <i class="fa fa-gear"></i>
+                        <p class="text-muted mb-2">Edition</p>
+                        <h6>{{adventure.edition}}</h6>
+                    </div>
+                    <div class="col-6 col-sm text-center">
+                        <i class="fa fa-globe"></i>
+                        <p class="text-muted mb-2">Setting</p>
+                        <h6>{{adventure.setting}}</h6>
+                    </div>
+                    <div class="col-6 col-sm text-center">
+                        <i class="fa fa-flag"></i>
+                        <p class="text-muted mb-2">Starting Level</p>
+                        <h6>
+                            {% if adventure.minStartingLevel is not null and adventure.maxStartingLevel is not null %}
+                                {% if adventure.minStartingLevel == adventure.maxStartingLevel %}
+                                    {{ adventure.minStartingLevel }}
+                                {% else %}
+                                    {{adventure.minStartingLevel}}-{{adventure.maxStartingLevel}}
+                                {% endif %}
                             {% else %}
-                                {{adventure.minStartingLevel}}-{{adventure.maxStartingLevel}}
+                                {{ adventure.startingLevelRange }}
                             {% endif %}
-                        {% else %}
-                            {{ adventure.startingLevelRange }}
-                        {% endif %}
-                    </h6>
-                </div>
-                <div class="col-6 col-sm text-center">
-                    <i class="fa fa-tree"></i>
-                    <p class="text-muted mb-2">Environment</p>
-                    <h6>{{adventure.environments|join(', ')}}</h6>
-                </div>
-                <div class="d-none d-sm-block col-sm text-center">
-                    <i class="fa fa-map"></i>
-                    <p class="text-muted mb-2">Tactical Maps</p>
-                    <h6>{{ adventure.tacticalMaps|bool2str }}</h6>
+                        </h6>
+                    </div>
+                    <div class="col-6 col-sm text-center">
+                        <i class="fa fa-tree"></i>
+                        <p class="text-muted mb-2">Environment</p>
+                        <h6>{{adventure.environments|join(', ')}}</h6>
+                    </div>
+                    <div class="d-none d-sm-block col-sm text-center">
+                        <i class="fa fa-map"></i>
+                        <p class="text-muted mb-2">Tactical Maps</p>
+                        <h6>{{ adventure.tacticalMaps|bool2str }}</h6>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-{% else %}
-    <div class="alert alert-danger">We're sorry. Apparently there is no adventure matching your search :(</div>
-{% endfor %}
+    {% else %}
+        <div class="alert alert-danger">We're sorry. Apparently there is no adventure matching your search :(</div>
+    {% endfor %}
+</div>
+
+<div class="d-flex justify-content-center">
+    <button type="submit" role="button" class="btn btn-secondary" id="load-more-btn"><i class="fa fa-spinner fa-spin d-none"></i> Load more results</button>
+</div>

--- a/app/Resources/webpack/index.js
+++ b/app/Resources/webpack/index.js
@@ -36,4 +36,4 @@ toastr.options = {
 
 // Lazy-load images using
 // https://github.com/verlok/lazyload
-const myLazyLoad = new LazyLoad();
+export const myLazyLoad = new LazyLoad();

--- a/app/Resources/webpack/search.js
+++ b/app/Resources/webpack/search.js
@@ -1,4 +1,4 @@
-import 'nouislider/distribute/nouislider.css';
+import {myLazyLoad} from "./index";
 
 (function () {
     const $page = $('#page--search-adventures');
@@ -30,5 +30,33 @@ import 'nouislider/distribute/nouislider.css';
     $('.filter-card .filters .show-more').on('click', function () {
         $(this).closest('.filters').find('.form-check').removeClass('d-none');
         $(this).remove();
+    });
+
+    let currentPage = 1;
+    const $searchForm = $("#search-form");
+    const $loadMoreBtn = $('#load-more-btn');
+    $loadMoreBtn.click(function () {
+        $loadMoreBtn.attr('disabled', true);
+        $loadMoreBtn.find('.fa-spin').removeClass('d-none');
+
+        const data = $searchForm.serialize() + '&page=' + ++currentPage;
+        $.ajax({
+            method: 'POST',
+            url: $searchForm.attr('action'),
+            data: data,
+        }).done(function (result) {
+            $('#search-results').append($(result).find('#search-results'));
+            myLazyLoad.update();
+        }).fail(function () {
+            alert('Something went wrong.');
+        }).always(function () {
+            $loadMoreBtn.attr('disabled', false);
+            $loadMoreBtn.find('.fa-spin').addClass('d-none');
+        });
+    });
+    $('#pagination-next-btn').click(function () {
+        $(this).attr('disabled', true);
+        $pageInput.val(parseInt($pageInput.val()) + 1);
+        $('#search-btn').click();
     });
 })();

--- a/src/AppBundle/Controller/AdventureController.php
+++ b/src/AppBundle/Controller/AdventureController.php
@@ -33,12 +33,15 @@ class AdventureController extends Controller
         $search = $this->get('adventure_search');
 
         $q = $request->get('q', '');
+        $page = (int)$request->get('page', 1);
         $filters = $request->get('f', []);
         $fields = $this->get('app.field_provider')->getFields();
-        list($adventures, $stats) = $search->search($q, $filters);
+        list($paginatedAdventureDocuments, $totalNumberOfResults, $stats) = $search->search($q, $filters, $page);
 
         return $this->render('adventure/index.html.twig', [
-            'adventures' => $adventures,
+            'adventures' => $paginatedAdventureDocuments,
+            'totalNumberOfResults' => $totalNumberOfResults,
+            'page' => $page,
             'stats' => $stats,
             'searchFilter' => $filters,
             'fields' => $fields,


### PR DESCRIPTION
This limits the search results to 50 adventures per page - to reduce loading time, bandwidth and don't crash or freeze browsers on low-end systems. Note that this approach doesn't really take much load off of ElasticSearch - they recommend using the [Search After](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-after.html) API if you have a lot of results. However, it wasn't immediately obvious to me how I'd implement it correctly. The [from/size approach](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html) will work for a maximum of 10.000 adventures, but I've added a hard limit of 5.000 for now.

This PR and #121 are the last things I see as important before we could push out another update, what do you think?