### PR TITLE
Add ability to add affiliate codes to urls

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
      mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS adl"
 
      # PHP
-     apt -y install php7.0 php7.0-curl php7.0-fpm php7.0-mysql php7.0-zip php7.0-cli php7.0-xml php7.0-mbstring php7.0-sqlite3 php-xdebug
+     apt -y install php7.0 php7.0-curl php7.0-fpm php7.0-mysql php7.0-zip php7.0-cli php7.0-xml php7.0-mbstring php7.0-sqlite3 php7.0-intl php-xdebug
 
      # Utilities
      apt -y install htop git nano vim

--- a/app/Resources/views/adventure/show.html.twig
+++ b/app/Resources/views/adventure/show.html.twig
@@ -44,7 +44,7 @@
                         {% if adventure.link %}
                             <div class="col">
                                 <div class="label">Link</div>
-                                <a href="{{ adventure.link|e('html_attr') }}">{{ adventure.link }}</a>
+                                <a href="{{ adventure.link|add_affiliate_code|e('html_attr') }}">{{ adventure.link|add_affiliate_code }}</a>
                             </div>
                         {% endif %}
                         <div class="col">

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -24,3 +24,18 @@ parameters:
 
     # Email addresses to be notified if an error occurs
     error_email_addresses: []
+
+    # Affiliate code mappings. Will be applied to the links on the adventure detail page.
+    # Each mapping can specify multiple domains. Subdomains are ignored.
+    # A query parameter named $param will be added or overridden and set to the value
+    # provided in $code. Example:
+    #
+    # affiliate_mappings:
+    #     - domains: ['drivethrurpg.com']
+    #       param:   'affiliate_id'
+    #       code:    'abc123'
+    #     - domains: ['amazon.de', 'amazon.com']
+    #       param:   'something'
+    #       code:    '123abc'
+
+    affiliate_mappings: []

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -32,6 +32,10 @@ services:
         tags:
             - { name: doctrine.event_subscriber, connection: default }
 
+    AppBundle\Twig\AppExtension:
+        arguments:
+            $affiliateMappings: '%affiliate_mappings%'
+
     twig.extension.date:
         class: Twig_Extensions_Extension_Date
         # For some reason the translation doesn't work if we autowire this service.

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "incenteev/composer-parameter-handler": "^2.0",
         "javiereguiluz/easyadmin-bundle": "^1.16",
         "knplabs/knp-paginator-bundle": "^2.6",
+        "league/uri": "^5.0",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "stof/doctrine-extensions-bundle": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed6e0fd4c2745d54a6fc1c0eb54afc6f",
+    "content-hash": "7418f55f83a616e291a4a18d89fa16dd",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1661,6 +1661,68 @@
             "time": "2014-01-12T16:20:24+00:00"
         },
         {
+            "name": "jeremykendall/php-domain-parser",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jeremykendall/php-domain-parser.git",
+                "reference": "896e7e70f02bd4fd77190052799bc61e4d779672"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jeremykendall/php-domain-parser/zipball/896e7e70f02bd4fd77190052799bc61e4d779672",
+                "reference": "896e7e70f02bd4fd77190052799bc61e4d779672",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "jeremykendall/debug-die": "0.0.1.*",
+                "mikey179/vfsstream": "~1.4",
+                "phpunit/phpunit": "~4.4"
+            },
+            "bin": [
+                "bin/parse",
+                "bin/update-psl"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Pdp\\": "src/"
+                },
+                "files": [
+                    "src/pdp-parse-url.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Kendall",
+                    "homepage": "http://about.me/jeremykendall",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/jeremykendall/php-domain-parser/graphs/contributors"
+                }
+            ],
+            "description": "Public Suffix List based URL parsing implemented in PHP.",
+            "homepage": "https://github.com/jeremykendall/php-domain-parser",
+            "keywords": [
+                "Public Suffix List",
+                "domain parsing",
+                "url parsing"
+            ],
+            "time": "2015-03-30T12:49:45+00:00"
+        },
+        {
             "name": "knplabs/knp-components",
             "version": "1.3.4",
             "source": {
@@ -1792,6 +1854,381 @@
                 "paginator"
             ],
             "time": "2017-06-09T15:25:39+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "ef6f413061bd4a9926c4c4394a5f5d384bfd8487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/ef6f413061bd4a9926c4c4394a5f5d384bfd8487",
+                "reference": "ef6f413061bd4a9926c4c4394a5f5d384bfd8487",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "league/uri-manipulations": "^1.0",
+                "league/uri-schemes": "^1.0",
+                "php": ">=7.0"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "http",
+                "https",
+                "middleware",
+                "parse_url",
+                "psr-7",
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "time": "2017-02-06T08:50:02+00:00"
+        },
+        {
+            "name": "league/uri-components",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-components.git",
+                "reference": "268c971e9ddeb079adc083d74556f14ddb54e4ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/268c971e9ddeb079adc083d74556f14ddb54e4ca",
+                "reference": "268c971e9ddeb079adc083d74556f14ddb54e4ca",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "jeremykendall/php-domain-parser": "^3.0",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\Components\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI components manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "authority",
+                "components",
+                "fragment",
+                "host",
+                "path",
+                "port",
+                "query",
+                "rfc3986",
+                "scheme",
+                "uri",
+                "url",
+                "userinfo"
+            ],
+            "time": "2017-08-10T13:35:19+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "dcc0be58e8b35a726274249e5eee053be1a56b66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/dcc0be58e8b35a726274249e5eee053be1a56b66",
+                "reference": "dcc0be58e8b35a726274249e5eee053be1a56b66",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\Interfaces\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common interface for URI representation",
+            "homepage": "http://github.com/thephpleague/uri-interfaces",
+            "keywords": [
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url"
+            ],
+            "time": "2017-01-04T08:02:42+00:00"
+        },
+        {
+            "name": "league/uri-manipulations",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-manipulations.git",
+                "reference": "3db42474cb68546ec9180d76dbf9807a8e1bcf98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-manipulations/zipball/3db42474cb68546ec9180d76dbf9807a8e1bcf98",
+                "reference": "3db42474cb68546ec9180d76dbf9807a8e1bcf98",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-components": "^1.0",
+                "league/uri-interfaces": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.9",
+                "guzzlehttp/psr7": "^1.2",
+                "league/uri-schemes": "^1.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "league/uri-schemes": "Allow manipulating URI objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\Modifiers\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "http://url.thephpleague.com",
+            "keywords": [
+                "formatter",
+                "manipulation",
+                "manipulations",
+                "middlewares",
+                "modifiers",
+                "psr-7",
+                "references",
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url"
+            ],
+            "time": "2017-02-06T07:57:03+00:00"
+        },
+        {
+            "name": "league/uri-parser",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-parser.git",
+                "reference": "2b756258c42f489eec5b89bf4030065070ee685b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-parser/zipball/2b756258c42f489eec5b89bf4030065070ee685b",
+                "reference": "2b756258c42f489eec5b89bf4030065070ee685b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-intl": "*",
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.9",
+                "phpbench/phpbench": "^0.12.2",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "league/uri-schemes": "Allow validating and normalizing URI parsing results"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "userland URI parser RFC 3986 compliant",
+            "homepage": "https://github.com/thephpleague/uri-parser",
+            "keywords": [
+                "parse_url",
+                "parser",
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "time": "2017-04-19T07:41:41+00:00"
+        },
+        {
+            "name": "league/uri-schemes",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-schemes.git",
+                "reference": "4d3db36201f8d90fbc8b30cb9ef7d2ea3881393d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-schemes/zipball/4d3db36201f8d90fbc8b30cb9ef7d2ea3881393d",
+                "reference": "4d3db36201f8d90fbc8b30cb9ef7d2ea3881393d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "league/uri-interfaces": "^1.0",
+                "league/uri-parser": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "league/uri-manipulations": "Needed to easily manipulate URI objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\Schemes\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file",
+                "ftp",
+                "http",
+                "https",
+                "parse_url",
+                "psr-7",
+                "rfc3986",
+                "uri",
+                "url",
+                "ws",
+                "wss"
+            ],
+            "time": "2017-08-10T15:28:21+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2195,6 +2632,56 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/link",
@@ -4111,56 +4598,6 @@
                 "Symfony2"
             ],
             "time": "2017-06-19T09:12:22+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "sensio/generator-bundle",

--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -2,12 +2,28 @@
 
 namespace AppBundle\Twig;
 
+use League\Uri\Components\Host;
+use League\Uri\Components\Query;
+use League\Uri\Modifiers\Formatter;
+use League\Uri\Schemes\Http;
+
 class AppExtension extends \Twig_Extension
 {
+    /**
+     * @var array
+     */
+    private $affiliateMappings = [];
+
+    public function __construct(array $affiliateMappings)
+    {
+        $this->affiliateMappings = $affiliateMappings;
+    }
+
     public function getFilters()
     {
         return [
             new \Twig_SimpleFilter('bool2str', [$this, 'bool2str']),
+            new \Twig_SimpleFilter('add_affiliate_code', [$this, 'addAffiliateCode'])
         ];
     }
 
@@ -18,5 +34,36 @@ class AppExtension extends \Twig_Extension
         }
 
         return $boolean ? 'Yes' : 'No';
+    }
+
+    /**
+     * @param string|null $url
+     * @return null
+     */
+    public function addAffiliateCode(string $url = null)
+    {
+        if ($url === null) {
+            return null;
+        }
+
+        $uri = Http::createFromString($url);
+        $domain = (new Host($uri->getHost()))->getRegisterableDomain();
+
+        foreach ($this->affiliateMappings as $affiliateMapping) {
+            foreach ($affiliateMapping['domains'] as $affiliateDomain) {
+                if ($affiliateDomain === $domain) {
+                    $queryParameters = Query::extract($uri->getQuery());
+                    $queryParameters[$affiliateMapping['param']] = $affiliateMapping['code'];
+
+                    $uri = $uri->withQuery(Query::createFromPairs($queryParameters)->getContent());
+                    break 2;
+                }
+            }
+        }
+
+        $formatter = new Formatter();
+        $formatter->setEncoding(Formatter::RFC3987_ENCODING);
+
+        return $formatter($uri);
     }
 }

--- a/tests/Twig/AppExtensionTest.php
+++ b/tests/Twig/AppExtensionTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+
+namespace Tests\Twig;
+
+use AppBundle\Twig\AppExtension;
+
+class AppExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AppExtension
+     */
+    private $extension;
+
+    public function setUp()
+    {
+        $this->extension = new AppExtension([
+            [
+                'domains' => ['example.com', 'example.org'],
+                'param' => 'aff_id',
+                'code' => 'aff_code'
+            ],
+            [
+                'domains' => ['foo.bar'],
+                'param' => 'aff_id2',
+                'code' => 'aff_code2'
+            ],
+        ]);
+    }
+    /**
+     * @dataProvider urlDataProvider
+     */
+    public function testAddAffiliateCode(string $inputUrl = null, string $expectedOutputUrl = null)
+    {
+        $this->assertEquals($expectedOutputUrl, $this->extension->addAffiliateCode($inputUrl));
+    }
+
+    public function urlDataProvider()
+    {
+        $unrelatedUrl = 'https://www.123.co.uk/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000#foo-bar&x=100';
+
+        return [
+            [null, null],
+            ['', ''],
+            [$unrelatedUrl, $unrelatedUrl],
+            ['http://example.com/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000#foo-bar&x=100', 'http://example.com/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000&aff_id=aff_code#foo-bar&x=100'],
+            ['http://example.org/?aff_id=test', 'http://example.org/?aff_id=aff_code'],
+            ['http://www.foo.bar/?aff_id=test&aff_id2=test2', 'http://www.foo.bar/?aff_id=test&aff_id2=aff_code2'],
+        ];
+    }
+}


### PR DESCRIPTION
New affiliate codes can be added via the `app/config/parameters.yml` file and must follow the format described here https://github.com/AdventureLookup/AdventureLookup/compare/dev...cmfcmf:feature/177-affiliate-code-logic?expand=1#diff-b21427cb85d0a014d5856b811168ad74R33.
This will require you to install the PHP mbstring and intl extensions:

    sudo apt install php7.0-mbstring php7.0-intl

closes #177 

@JohnnyFlash does this add all the functionality we need?