### PR TITLE
Rename tactical maps to battle mats

### DIFF
--- a/app/Resources/views/adventure/search_results.html.twig
+++ b/app/Resources/views/adventure/search_results.html.twig
@@ -49,7 +49,7 @@
                     </div>
                     <div class="d-none d-sm-block col-sm text-center">
                         <i class="fa fa-map"></i>
-                        <p class="text-muted mb-2">Tactical Maps</p>
+                        <p class="text-muted mb-2">Battle Mats</p>
                         <h6>{{ adventure.tacticalMaps|bool2str }}</h6>
                     </div>
                 </div>

--- a/app/Resources/views/adventure/show.html.twig
+++ b/app/Resources/views/adventure/show.html.twig
@@ -109,7 +109,7 @@
                             {{ macros.search_icon('handouts', adventure.handouts) }}
                         </div>
                         <div class="col">
-                            <div class="label">Tactical Maps?</div>
+                            <div class="label">Battle Mats?</div>
                             {{ adventure.tacticalMaps|bool2str }}
                             {{ macros.search_icon('tacticalMaps', adventure.tacticalMaps) }}
                         </div>

--- a/src/AppBundle/Field/FieldProvider.php
+++ b/src/AppBundle/Field/FieldProvider.php
@@ -158,7 +158,7 @@ class FieldProvider
                 'boolean',
                 false,
                 false,
-                'Tactical Maps'
+                'Battle Mats'
             ),
 
             'foundIn' => new Field(

--- a/src/AppBundle/Form/AdventureType.php
+++ b/src/AppBundle/Form/AdventureType.php
@@ -199,14 +199,14 @@ class AdventureType extends AbstractType
                 'expanded' => true,
             ])
             ->add('tacticalMaps', ChoiceType::class, [
-                'help' => 'Whether or not tactical maps are provided.',
+                'help' => 'Whether or not battle mats are provided.',
                 'required' => false,
                 'choices' => [
                     'Yes' => true,
                     'No' => false,
                 ],
                 'placeholder' => 'Unknown',
-                'label' => 'Tactical Maps',
+                'label' => 'Battle Mats',
                 'expanded' => true,
             ])
             ->add('handouts', ChoiceType::class, [


### PR DESCRIPTION
This does not rename the field from at the code side / datastructures, because I didn't want to rename everything again if we decided to rename the field once more. Proper renaming throughout the code should be done once things calm down and the field names don't change anymore.

closes #191 