### PR TITLE
Let setEdition, setPublisher and setSetting accept null

### DIFF
--- a/src/AppBundle/Entity/Adventure.php
+++ b/src/AppBundle/Entity/Adventure.php
@@ -341,9 +341,11 @@ class Adventure
      *
      * @return Adventure
      */
-    public function setEdition($edition)
+    public function setEdition(Edition $edition = null)
     {
-        $edition->addAdventure($this);
+        if ($edition !== null) {
+            $edition->addAdventure($this);
+        }
         $this->edition = $edition;
         return $this;
     }
@@ -423,9 +425,11 @@ class Adventure
      *
      * @return Adventure
      */
-    public function setPublisher($publisher)
+    public function setPublisher(Publisher $publisher = null)
     {
-        $publisher->addAdventure($this);
+        if ($publisher !== null) {
+            $publisher->addAdventure($this);
+        }
         $this->publisher = $publisher;
         return $this;
     }
@@ -442,9 +446,11 @@ class Adventure
      * @param Setting $setting
      * @return Adventure
      */
-    public function setSetting(Setting $setting)
+    public function setSetting(Setting $setting = null)
     {
-        $setting->addAdventure($this);
+        if ($setting !== null) {
+            $setting->addAdventure($this);
+        }
         $this->setting = $setting;
         return $this;
     }

--- a/tests/AppBundle/Entity/AdventureTest.php
+++ b/tests/AppBundle/Entity/AdventureTest.php
@@ -4,7 +4,10 @@
 namespace Tests\AppBundle\Entity;
 
 use AppBundle\Entity\Adventure;
+use AppBundle\Entity\Edition;
 use AppBundle\Entity\Monster;
+use AppBundle\Entity\Publisher;
+use AppBundle\Entity\Setting;
 use Doctrine\Common\Collections\ArrayCollection;
 
 class AdventureTest extends \PHPUnit_Framework_TestCase
@@ -85,6 +88,33 @@ class AdventureTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(5, $this->subject->getMonsters());
         $this->assertCount(3, $this->subject->getCommonMonsters());
         $this->assertCount(2, $this->subject->getBossMonsters());
+    }
+
+    public function testEdition()
+    {
+        $this->subject->setEdition(null);
+        $this->assertSame(null, $this->subject->getEdition());
+        $edition = new Edition();
+        $this->subject->setEdition($edition);
+        $this->assertSame($edition, $this->subject->getEdition());
+    }
+
+    public function testPublisher()
+    {
+        $this->subject->setPublisher(null);
+        $this->assertSame(null, $this->subject->getPublisher());
+        $publisher = new Publisher();
+        $this->subject->setPublisher($publisher);
+        $this->assertSame($publisher, $this->subject->getPublisher());
+    }
+
+    public function testSetting()
+    {
+        $this->subject->setSetting(null);
+        $this->assertSame(null, $this->subject->getSetting());
+        $setting = new Setting();
+        $this->subject->setSetting($setting);
+        $this->assertSame($setting, $this->subject->getSetting());
     }
 
     private function makeCommonMonster(): Monster


### PR DESCRIPTION
It looks like currently you cannot set edition, publisher or setting to null after you set them to something else.