### PR TITLE
Fixes a few bugs introduced in the bulk edit update

### DIFF
--- a/app/DoctrineMigrations/Version20170816131325.php
+++ b/app/DoctrineMigrations/Version20170816131325.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
- * Adds the createdAt field and populates it with data logged in the log entries table
+ * Adds the createdAt field (nullable, will be populated and made not null in next migration)
  */
 class Version20170816131325 extends AbstractMigration
 {
@@ -18,10 +18,6 @@ class Version20170816131325 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE adventure ADD created_at DATETIME NULL');
-        $this->addSql("UPDATE adventure a
-            LEFT JOIN ext_log_entries l ON l.object_id = a.id AND l.action = 'create' AND l.object_class = 'AppBundle\\\\Entity\\\\Adventure'
-            SET a.created_at = l.logged_at");
-        $this->addSql('ALTER TABLE adventure MODIFY created_at DATETIME NOT NULL');
     }
 
     /**

--- a/app/DoctrineMigrations/Version20170818080730.php
+++ b/app/DoctrineMigrations/Version20170818080730.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Populates the created_at field with data logged in the log entries table and makes it not nullable.
+ */
+class Version20170818080730 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql("UPDATE adventure a SET a.created_at = ( 
+            SELECT MIN(l.logged_at)  
+            FROM ext_log_entries l  
+            WHERE 
+            (l.object_id = a.id AND l.object_class = 'AppBundle\\\\Entity\\\\Adventure')
+            OR
+            (l.object_id IN (SELECT tc.id FROM tag_content tc WHERE tc.adventure_id = a.id) AND l.object_class = 'AppBundle\\\\Entity\\\\TagContent')
+        )");
+        $this->addSql('ALTER TABLE adventure MODIFY created_at DATETIME NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE adventure MODIFY created_at DATETIME NULL');
+    }
+}

--- a/src/AppBundle/Controller/CurationController.php
+++ b/src/AppBundle/Controller/CurationController.php
@@ -3,11 +3,9 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Curation\BulkEditFormHandler;
-use AppBundle\Curation\BulkEditFormHelper;
 use AppBundle\Curation\BulkEditFormProvider;
 use AppBundle\Entity\Adventure;
 use AppBundle\Entity\ChangeRequest;
-use AppBundle\Repository\AdventureRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use Knp\Component\Pager\PaginatorInterface;


### PR DESCRIPTION
- Split migration to avoid implicit DDL commits (MySQL commits automatically after DDL changes, if the following DML query fails, the migration cannot completely be rolled back)
- improve createdAt detection, previously didn't return a result for some adventures (query runs for ~90 seconds at dev server)
- fix another edge case related to common/boss monsters...

I have already tested an update from master to this branch on the dev server.