### PR TITLE
Fix for issue #210

### DIFF
--- a/app/Resources/views/adventure/search_filters.html.twig
+++ b/app/Resources/views/adventure/search_filters.html.twig
@@ -11,10 +11,16 @@
     </div>
 {% endmacro %}
 
-{% macro filter_field(field, stats, searchFilter) %}
+{% macro filter_field(field, stats, searchFilter, hidden) %}
     {% import _self as macros %}
     {% set filter = searchFilter[field.name]|default([]) %}
     {% set show = true %} {# Currently, all filters are shown and expanded when the page is loaded #}
+    {% if hidden %}
+        {% set value = filter['v']|default('') %}
+        {% if value %}
+        <input type="hidden" name="f[{{ field.name }}][v]" value="{{ value }}" >
+        {% endif %}
+    {% else %}
     <div class="card mb-1 filter-card {{ show ? 'expanded' : '' }}" id="filter-{{ field.name }}">
         <div class="card-block filter-title">
             <h6 class="card-title">
@@ -83,26 +89,30 @@
             <button type="submit" class="btn btn-secondary pull-right btn-sm" role="button">Apply</button>
         </div>
     </div>
+    {% endif %}
 {% endmacro %}
 {% import _self as macros %}
-{{ macros.filter_field(fields['publisher'], stats, searchFilter) }}
-{{ macros.filter_field(fields['setting'], stats, searchFilter) }}
-{{ macros.filter_field(fields['edition'], stats, searchFilter) }}
-
-{{ macros.filter_field(fields['environments'], stats, searchFilter) }}
-{{ macros.filter_field(fields['items'], stats, searchFilter) }}
-{{ macros.filter_field(fields['bossMonsters'], stats, searchFilter) }}
-{{ macros.filter_field(fields['commonMonsters'], stats, searchFilter) }}
-
-{{ macros.filter_field(fields['numPages'], stats, searchFilter) }}
-{{ macros.filter_field(fields['minStartingLevel'], stats, searchFilter) }}
-{{ macros.filter_field(fields['maxStartingLevel'], stats, searchFilter) }}
-{{ macros.filter_field(fields['startingLevelRange'], stats, searchFilter) }}
-
-{{ macros.filter_field(fields['soloable'], stats, searchFilter) }}
-{{ macros.filter_field(fields['pregeneratedCharacters'], stats, searchFilter) }}
-{{ macros.filter_field(fields['handouts'], stats, searchFilter) }}
-{{ macros.filter_field(fields['tacticalMaps'], stats, searchFilter) }}
-
-{{ macros.filter_field(fields['partOf'], stats, searchFilter) }}
-{{ macros.filter_field(fields['foundIn'], stats, searchFilter) }}
+{% 
+set visible_fields = [
+              'publisher',
+              'setting',
+              'edition',
+              'environments',
+              'items',
+              'bossMonsters',
+              'commonMonsters',
+              'numPages',
+              'minStartingLevel',
+              'maxStartingLevel',
+              'startingLevelRange',
+              'soloable',
+              'pregeneratedCharacters',
+              'handouts',
+              'tacticalMaps',
+              'partOf',
+              'foundIn'
+             ]
+%}
+{% for field in fields %}
+{{ macros.filter_field(field, stats, searchFilter, field.name not in visible_fields) }}
+{% endfor %}

--- a/app/Resources/views/adventure/search_results.html.twig
+++ b/app/Resources/views/adventure/search_results.html.twig
@@ -56,10 +56,17 @@
             </div>
         </div>
     {% else %}
-        <div class="alert alert-danger">We're sorry. Apparently there is no adventure matching your search :(</div>
+        {% if totalNumberOfResults == 0 %}
+        <div class="alert alert-danger">We're sorry. Apparently there is no adventure matching your search. :(</div>
+        {% elseif adventures|length == 0 %}
+        <div class="alert alert-info">No more results match your search criteria.</div>
+        {% endif %}
     {% endfor %}
 </div>
 
 <div class="d-flex justify-content-center">
-    <button type="submit" role="button" class="btn btn-secondary" id="load-more-btn"><i class="fa fa-spinner fa-spin d-none"></i> Load more results</button>
+    <button type="submit" role="button" class="btn btn-secondary" id="load-more-btn" {% if adventures|length == 0 %}disabled{% endif %}>
+        <i class="fa fa-spinner fa-spin d-none"></i>
+        Load more results
+    </button>
 </div>

--- a/app/Resources/webpack/search.js
+++ b/app/Resources/webpack/search.js
@@ -18,7 +18,12 @@ import {myLazyLoad} from "./index";
         const key = $(this).data('key');
         const fieldType = $(this).data('field-type');
         if (fieldType === 'string') {
-            $(`input[name^="f[${fieldName}][v]"][value="${value}"]`).prop('checked', false);
+            const $strInput = $(`input[name^="f[${fieldName}][v]"][value="${value}"]`);
+            if($strInput.is(':hidden')){
+                $strInput.remove()
+            } else {
+                $strInput.prop('checked', false);
+            }
         } else if (fieldType === 'boolean') {
             $(`input[name^="f[${fieldName}][v]"][value=""]`).prop('checked', true);
         } else if (fieldType === 'integer') {
@@ -47,11 +52,14 @@ import {myLazyLoad} from "./index";
             data: data,
         }).done(function (result) {
             $('#search-results').append($(result).find('#search-results'));
+
+            const $newLoadMoreBtn = $(result).find('#load-more-btn')[0];
+            $loadMoreBtn.attr('disabled', $($newLoadMoreBtn).is(':disabled'));
+
             myLazyLoad.update();
         }).fail(function () {
             alert('Something went wrong.');
         }).always(function () {
-            $loadMoreBtn.attr('disabled', false);
             $loadMoreBtn.find('.fa-spin').addClass('d-none');
         });
     });


### PR DESCRIPTION
- "Load more results" button disables with an info message if no more adventures are available.
- Fields not in the explicit filter list but in the search criteria from other pages are retained on the main page through hidden form input elements.
- Fields visible for rendering in filters on the main page are managed in a list.