### PR TITLE
Remove bottom margins from checkbox filters for compactness. Issue #199.

### DIFF
--- a/app/Resources/webpack/sass/search.scss
+++ b/app/Resources/webpack/sass/search.scss
@@ -7,6 +7,9 @@
   .filter-title {
     cursor: pointer;
   }
+  .form-check {
+      margin-bottom: 0;
+  }
 
   // Default state, filter not expanded
   .fa-caret-up, .filter-content {


### PR DESCRIPTION
Add a new class to search sass to remove bottom margins from the check boxes.