### PR TITLE
Fixed wording for search instructions

### DIFF
--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -18,7 +18,7 @@
                             <button type="submit" class="btn btn-primary" role="button" id="search-btn">Search</button>
                         </span>
                     </div>
-                    <small class="form-text text-muted">Things you type in here will be split at <code>,</code> and then <code>AND</code>ed. Use the filters below for advanced searches (hit the 'Search' button again after filtering).</small>
+                    <small class="form-text text-muted">Seperate distinct search terms with a <code>,</code>. Results will include all search terms. Use the filters below for advanced searches (hit the 'Search' button again after filtering).</small>
                     <div class="row my-3">
                         <div class="col-md-3">
                             <div class="alert alert-info d-md-none">


### PR DESCRIPTION
Fixed the wording of the search instructions on the homepage to 

`Seperate distinct search terms with a <code>,</code>. Results will include all search terms.`

Are we happy with this? This is my first PR!

Fixes #125 