### PR TITLE
Remove nfs from Vagrantfile for non-windows users

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,14 +6,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 8001, host: 8001
   config.vm.network "forwarded_port", guest: 9200, host: 9200
-
-  if Vagrant::Util::Platform.windows? then
-    puts "Windows OS detected - using slow shared folders."
-    config.vm.synced_folder ".", "/vagrant"
-  else
-    puts "Non-Windows OS detected - using nfs to share folder."
-    config.vm.synced_folder ".", "/vagrant", :nfs => true
-  end
+  config.vm.synced_folder ".", "/vagrant"
 
   config.vm.network "private_network", type: "dhcp"
 


### PR DESCRIPTION
During my initial efforts to stand up AdventureLookup locally I ran into the issue outlined in https://github.com/AdventureLookup/AdventureLookup/issues/243.

I believe it has something to do with the handling of users/groups on the VM and how Symfony stores sessions on disk in dev. The writing of the sessions is denied, and thus the app does not work.

Since NFS is not used by the Windows developers (current active devs as far as I understand) I would suggest removing this since it doesn't work, and if someone wants to add it back they can solve the underlying problem.