### PR TITLE
fix link to Matt Coleville's twitter

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -50,7 +50,7 @@
                             <a href="https://www.reddit.com/r/AdventureLookup/comments/6th0n4/apply_here_to_be_a_curator/">apply here</a>
                             to be promoted to a curator.
                         <br>
-                            <a href="twitter.com/mattcolville">Matt Colville</a> first talked about the idea in
+                            <a href="https://twitter.com/mattcolville">Matt Colville</a> first talked about the idea in
                             <a href="https://www.youtube.com/watch?v=PIyLvicSu78">a video of his</a>
                             in 2016. It wasn't until August 2017 before
                             <a href="https://www.youtube.com/watch?v=D3OllWSRhuI">the site went live</a>.


### PR DESCRIPTION
Old link lacked the `https://`, and so ultimately linked to `https://www.adventurelookup.com/adventures/twitter.com/mattcolville`, which... is not a thing.