### PR TITLE
Correctly download composer, make install quieter, add composer plugins

### DIFF
--- a/scripts/install-composer.sh
+++ b/scripts/install-composer.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet --install-dir=/usr/bin --filename=composer
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
Make a few improvements to the vagrant box, 
- Make the installation quieter
- Composer was not correctly downloaded any longer, use the recommended script to download composer
- Added a 2GB swap file, because the memory isn't sufficient for some composer commands
- Fixed PhantomJS installation by installing the missing `libfontconfig1` package
- Increased PHP realpath cache size, which should speed things up a bit
- Replaced `apt` by `apt-get` to remove warnings about unstable command line interface