### PR TITLE
Validate the $filter argument to be an array

### DIFF
--- a/src/AppBundle/Controller/AdventureController.php
+++ b/src/AppBundle/Controller/AdventureController.php
@@ -38,6 +38,9 @@ class AdventureController extends Controller
         $q = $request->get('q', '');
         $page = (int)$request->get('page', 1);
         $filters = $request->get('f', []);
+        if (!is_array($filters)) {
+            $filters = [];
+        }
         $fields = $fieldProvider->getFields();
         list($paginatedAdventureDocuments, $totalNumberOfResults, $stats) = $adventureSearch->search($q, $filters, $page);
 

--- a/tests/AppBundle/Controller/AdventureControllerTest.php
+++ b/tests/AppBundle/Controller/AdventureControllerTest.php
@@ -8,6 +8,15 @@ use Tests\WebTestCase;
 
 class AdventureControllerTest extends WebTestCase
 {
+    public function testInvalidFilters()
+    {
+        $this->loadFixtures([AdventureData::class]);
+
+        $session = $this->makeSession();
+        $session->visit('/adventures/?filters=not-an-array');
+        $this->assertTrue($session->getPage()->hasContent('A community for lazy dungeon masters'));
+    }
+
     public function testDelete()
     {
         $referenceRepository = $this->loadFixtures([AdventureData::class])->getReferenceRepository();


### PR DESCRIPTION
Sometimes users supply a non-array as `$filters` argument, which results in a server error. This fixes the behaviour by silently discarding the `$filters` argument.