### PR TITLE
Switch to Google Chrome headless instead of PhantomJS for browser tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: trusty
-
+sudo: false
 language: php
-
 php:
   - '7.0.21'
 
@@ -13,23 +12,37 @@ env:
     - TESTSUITE=unittests
     - TESTSUITE=functional
     - TESTSUITE=browser
+    - TESTSUITE=lint
 
 services:
   # ElasticSearch takes few seconds to start, but it also takes a while until
-  # we finally execute the tests, no need to wait!
+  # we start executing the tests, so there is no need to wait for it to be
+  # up and running.
   # https://docs.travis-ci.com/user/database-setup/#ElasticSearch
   - elasticsearch
+
+addons:
+  chrome: stable
 
 cache:
   directories:
     - $HOME/.composer/cache/files
     - node_modules
 
+before_install:
+  - INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo date.timezone = Europe/Berlin >> $INI
+  - echo memory_limit = -1 >> $INI
+  - |
+    if [ ${TESTSUITE} == "browser" ] || [ "$TESTSUITE" == "lint" ]; then
+      phpenv config-rm xdebug.ini || echo "xdebug not available";
+    fi;
+
 install:
-  - composer install -n
+  - composer install -n --no-suggest --no-progress --ansi
   - |
     if [ ${TESTSUITE} == "functional" ] || [ "$TESTSUITE" == "browser" ]; then
-      npm install npm@latest -g
+      npm install -g npm
       npm install;
       npm run prod;
     fi;
@@ -43,26 +56,17 @@ before_script:
 
 script:
   - set -e
-  # Check for Twig and Yaml syntax errors
-  - php bin/console lint:twig app
-  - php bin/console lint:yaml app
-  # Check for security issues in installed dependencies
-  #   Specifying the endpoint is a (temporary) fix for Travis, see:
-  #   https://github.com/travis-ci/travis-ci/issues/6339
-  #   https://github.com/sensiolabs/security-checker/pull/77#issuecomment-290733113
-  - php bin/console security:check --end-point=http://security.sensiolabs.org/check_lock
-  # Start server and PhantomJS if browser tests are executed
   - |
-    if [[ ${TESTSUITE} == "browser" ]]; then
-      bash scripts/start-phantomjs.sh
-    fi;
-  # Execute tests
-  # Only gather coverage on PHP 7.1, ignore browser tests for coverage.
-  - |
-    if [ "$TESTSUITE" == "browser" ]; then
-      $PHPUNIT --testsuite $TESTSUITE;
+    if [ ${TESTSUITE} == "browser" ]; then
+      bash scripts/prepare-browser-tests.sh
+      sleep 5
+      $PHPUNIT --testsuite $TESTSUITE
+    elif [ ${TESTSUITE} == "lint" ]; then
+      php bin/console lint:twig app
+      php bin/console lint:yaml app
+      php bin/console security:check --end-point=http://security.sensiolabs.org/check_lock
     else
-      $PHPUNIT --testsuite $TESTSUITE --coverage-clover=coverage.xml;
+      $PHPUNIT --testsuite $TESTSUITE --coverage-clover=coverage.xml
       bash <(curl -s https://codecov.io/bash) -X gcov -X coveragepy
     fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,11 @@ cache:
     - $HOME/.composer/cache/files
     - node_modules
 
+stages:
+  - test
+  - name: deploy
+    if: branch = dev
+
 before_install:
   - INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo date.timezone = Europe/Berlin >> $INI

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Functional tests can be executed like so:
 ```
 php vendor/symfony/phpunit-bridge/bin/simple-phpunit --testsuite functional
 ```
-Browser tests require PhantomJS as well as the application running in the test environment. 
-To do that, execute `bash scripts/start-phantomjs.sh` *once* before executing the tests. There is no
+Browser tests require Google Chrome with remote debugging enabled as well as the application running in the test environment. 
+To do that, execute `bash scripts/prepare-browser-tests.sh` *once* before executing the tests. There is no
 need to call the script again until you reboot. Then execute the following to run the browser tests:
 ```
 php vendor/symfony/phpunit-bridge/bin/simple-phpunit --testsuite browser
@@ -116,15 +116,16 @@ Make sure to run `mysql_secure_installation`. Adjust port, username, host and pa
 
 ## Ports used in development
 
-| Port | Forwarded to host machine | Purpose                                        |
-|------|---------------------------|------------------------------------------------|
-| 3306 | no                        | MySQL                                          |
-| 8000 | yes                       | Application dev server                         |
-| 8001 | yes                       | Webpack dev server if run from within Vagrant  |
-| 8002 | no                        | Webpack dev server if run from outside Vagrant |
-| 8003 | no                        | Application test server                        |
-| 8510 | no                        | PhantomJS server                               |
-| 9200 | yes                       | ElasticSearch                                  |
+| Port | Forwarded to host machine | Purpose                                           |
+|------|---------------------------|---------------------------------------------------|
+| 3306 | no                        | MySQL                                             |
+| 5900 | yes                       | VNC server (see scripts/prepare-browser-tests.sh) |
+| 8000 | yes                       | Application dev server                            |
+| 8001 | yes                       | Webpack dev server if run from within Vagrant     |
+| 8002 | no                        | Webpack dev server if run from outside Vagrant    |
+| 8003 | no                        | Application test server                           |
+| 9200 | yes                       | ElasticSearch                                     |
+| 9222 | no                        | Chrome Remote Debugging                           |
 
 # Tools used
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
+  config.vm.network "forwarded_port", guest: 5900, host: 5900
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 8001, host: 8001
   config.vm.network "forwarded_port", guest: 9200, host: 9200
@@ -59,12 +60,13 @@ Vagrant.configure("2") do |config|
      # Update NPM
      npm install npm@latest -g --loglevel=warn
 
-     # PhantomJS headless browser
-     wget -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
-     tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2
-     mv phantomjs-2.1.1-linux-x86_64 /opt/phantomjs
-     ln -s /opt/phantomjs/bin/phantomjs /usr/bin/phantomjs
-     apt-get -y -qq install libfontconfig1
+     # Headless testing utilities
+     apt-get -y -qq install xvfb x11vnc fluxbox
+     # Chrome
+     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+     echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+     apt-get -y -qq update
+     apt-get -y -qq install google-chrome-stable
 
      # Composer (PHP Package Manager)
      bash /vagrant/scripts/install-composer.sh

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "jcalderonzumba/mink-phantomjs-driver": "^0.3.3",
         "liip/functional-test-bundle": "^1.8",
         "sensio/generator-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^3.0",
+        "symfony/phpunit-bridge": "^4.0.6",
         "symfony/web-server-bundle": "^3.3"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
     "require-dev": {
         "behat/mink": "^1.7",
         "behat/mink-browserkit-driver": "^1.3",
+        "dmore/chrome-mink-driver": "^2.6",
         "doctrine/doctrine-fixtures-bundle": "^2.3",
-        "jcalderonzumba/mink-phantomjs-driver": "^0.3.3",
         "liip/functional-test-bundle": "^1.8",
         "sensio/generator-bundle": "^3.0",
         "symfony/phpunit-bridge": "^4.0.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bc4606cf7089399d10f49eee04760c3",
+    "content-hash": "bea5f89efeea1cb8c4ca8e7f53eb5e2a",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -4657,16 +4657,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.3.9",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "27d159bd9bd14a3bd9d3e136081c321a0d621c03"
+                "reference": "14ffbbe2a72d0f6339b24eb830dd38cf63ba6630"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/27d159bd9bd14a3bd9d3e136081c321a0d621c03",
-                "reference": "27d159bd9bd14a3bd9d3e136081c321a0d621c03",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/14ffbbe2a72d0f6339b24eb830dd38cf63ba6630",
+                "reference": "14ffbbe2a72d0f6339b24eb830dd38cf63ba6630",
                 "shasum": ""
             },
             "require": {
@@ -4685,7 +4685,11 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.0-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
                 }
             },
             "autoload": {
@@ -4715,7 +4719,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-09-05T11:23:06+00:00"
+            "time": "2018-02-19T16:50:22+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bea5f89efeea1cb8c4ca8e7f53eb5e2a",
+    "content-hash": "31cc5e870040b1623f0b6a94d2c82dfc",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -4112,6 +4112,53 @@
             "time": "2016-03-05T08:59:47+00:00"
         },
         {
+            "name": "dmore/chrome-mink-driver",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/DMore/chrome-mink-driver.git",
+                "reference": "42c5e61d570e3089eca08915d2e2720d81a3fe1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/DMore%2Fchrome-mink-driver/repository/archive.zip?sha=42c5e61d570e3089eca08915d2e2720d81a3fe1b",
+                "reference": "42c5e61d570e3089eca08915d2e2720d81a3fe1b",
+                "shasum": ""
+            },
+            "require": {
+                "behat/mink": "^1.7",
+                "ext-curl": "*",
+                "textalk/websocket": "^1.2.0"
+            },
+            "require-dev": {
+                "mink/driver-testsuite": "dev-master",
+                "phpunit/phpunit": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DMore\\ChromeDriver\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dorian More",
+                    "email": "doriancmore@gmail.com"
+                }
+            ],
+            "description": "Mink driver for controlling chrome without selenium",
+            "time": "2018-01-31T21:51:21+00:00"
+        },
+        {
             "name": "doctrine/data-fixtures",
             "version": "v1.2.2",
             "source": {
@@ -4226,302 +4273,6 @@
                 "persistence"
             ],
             "time": "2017-09-10T23:22:01+00:00"
-        },
-        {
-            "name": "guzzlehttp/guzzle",
-            "version": "6.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
-                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4",
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "^4.0 || ^5.0",
-                "psr/log": "^1.0"
-            },
-            "suggest": {
-                "psr/log": "Required for using the Log middleware"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.2-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2017-06-22T18:50:49+00:00"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "v1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "time": "2016-12-20T10:07:11+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "time": "2017-03-20T17:10:46+00:00"
-        },
-        {
-            "name": "jcalderonzumba/gastonjs",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jcalderonzumba/gastonjs.git",
-                "reference": "575a9c18d8b87990c37252e8d9707b29f0a313f3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jcalderonzumba/gastonjs/zipball/575a9c18d8b87990c37252e8d9707b29f0a313f3",
-                "reference": "575a9c18d8b87990c37252e8d9707b29f0a313f3",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/guzzle": "~5.0|~6.0",
-                "php": ">=5.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.6",
-                "silex/silex": "~1.2",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/process": "~2.1"
-            },
-            "type": "phantomjs-api",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zumba\\GastonJS\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Juan Francisco Calderón Zumba",
-                    "email": "juanfcz@gmail.com",
-                    "homepage": "http://github.com/jcalderonzumba"
-                }
-            ],
-            "description": "PhantomJS API based server for webpage automation",
-            "homepage": "https://github.com/jcalderonzumba/gastonjs",
-            "keywords": [
-                "api",
-                "automation",
-                "browser",
-                "headless",
-                "phantomjs"
-            ],
-            "time": "2017-03-31T07:31:47+00:00"
-        },
-        {
-            "name": "jcalderonzumba/mink-phantomjs-driver",
-            "version": "v0.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jcalderonzumba/MinkPhantomJSDriver.git",
-                "reference": "008f43670e94acd39273d15add1e7348eb23848d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jcalderonzumba/MinkPhantomJSDriver/zipball/008f43670e94acd39273d15add1e7348eb23848d",
-                "reference": "008f43670e94acd39273d15add1e7348eb23848d",
-                "shasum": ""
-            },
-            "require": {
-                "behat/mink": "~1.7",
-                "jcalderonzumba/gastonjs": "~1.0",
-                "php": ">=5.4",
-                "twig/twig": "~1.20|~2.0"
-            },
-            "require-dev": {
-                "mink/driver-testsuite": "dev-master",
-                "phpunit/phpunit": "~4.6"
-            },
-            "type": "mink-driver",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zumba\\Mink\\Driver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Juan Francisco Calderón Zumba",
-                    "email": "juanfcz@gmail.com",
-                    "homepage": "http://github.com/jcalderonzumba"
-                }
-            ],
-            "description": "PhantomJS driver for Mink framework",
-            "homepage": "http://mink.behat.org/",
-            "keywords": [
-                "ajax",
-                "browser",
-                "headless",
-                "javascript",
-                "phantomjs",
-                "testing"
-            ],
-            "time": "2016-12-01T10:57:30+00:00"
         },
         {
             "name": "liip/functional-test-bundle",
@@ -4720,6 +4471,45 @@
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
             "time": "2018-02-19T16:50:22+00:00"
+        },
+        {
+            "name": "textalk/websocket",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Textalk/websocket-php.git",
+                "reference": "bfa18bb6bf523680c7803f6b04694fbbf2f67bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Textalk/websocket-php/zipball/bfa18bb6bf523680c7803f6b04694fbbf2f67bbf",
+                "reference": "bfa18bb6bf523680c7803f6b04694fbbf2f67bbf",
+                "shasum": ""
+            },
+            "require-dev": {
+                "cboden/ratchet": "0.3.*",
+                "phpunit/phpunit": "4.1.*",
+                "phpunit/phpunit-selenium": "1.3.3",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WebSocket\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fredrik Liljegren",
+                    "email": "fredrik.liljegren@textalk.se"
+                }
+            ],
+            "description": "WebSocket client and server",
+            "time": "2015-10-09T07:32:42+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="app/" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
     </php>
 
     <testsuites>

--- a/scripts/prepare-browser-tests.sh
+++ b/scripts/prepare-browser-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+php bin/console server:start 8003 --env test --pidfile /tmp/adl-test-server.pid
+
+# Start in headless mode
+google-chrome-stable --no-sandbox --headless --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 http://localhost:8003 &
+
+#
+# Alternatively, start Chrome in a virtual display with a VNC server.
+# You can connect to the server with a VNC viewer from your host machine at localhost:5900.
+#
+
+# Xvfb :42 -screen 0 1024x768x16 &
+# x11vnc -display :42 -bg -nopw -listen 0.0.0.0 -xkb
+# DISPLAY=:42 fluxbox &
+# DISPLAY=:42 google-chrome-stable --no-sandbox --start-maximized --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 http://localhost:8003 &

--- a/scripts/start-phantomjs.sh
+++ b/scripts/start-phantomjs.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -ev
-php bin/console server:start 8003 --env test --pidfile /tmp/adl-test-server.pid
-phantomjs --ssl-protocol=any --ignore-ssl-errors=true vendor/jcalderonzumba/gastonjs/src/Client/main.js 8510 1024 768 2>&1 >> /tmp/gastonjs.log &

--- a/tests/AppBundle/Curation/BulkEditFormHandlerTest.php
+++ b/tests/AppBundle/Curation/BulkEditFormHandlerTest.php
@@ -9,11 +9,12 @@ use AppBundle\Entity\Adventure;
 use AppBundle\Field\Field;
 use AppBundle\Repository\AdventureRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class BulkEditFormHandlerTest extends \PHPUnit_Framework_TestCase
+class BulkEditFormHandlerTest extends TestCase
 {
     /**
      * @var BulkEditFormHandler
@@ -21,22 +22,22 @@ class BulkEditFormHandlerTest extends \PHPUnit_Framework_TestCase
     private $formHandler;
 
     /**
-     * @var Request|PHPUnit_Framework_MockObject_MockObject
+     * @var Request|MockObject
      */
     private $request;
 
     /**
-     * @var Field|PHPUnit_Framework_MockObject_MockObject
+     * @var Field|MockObject
      */
     private $field;
 
     /**
-     * @var AdventureRepository|PHPUnit_Framework_MockObject_MockObject
+     * @var AdventureRepository|MockObject
      */
     private $repository;
 
     /**
-     * @var FormInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var FormInterface|MockObject
      */
     private $form;
 

--- a/tests/AppBundle/Curation/BulkEditFormProviderTest.php
+++ b/tests/AppBundle/Curation/BulkEditFormProviderTest.php
@@ -11,7 +11,8 @@ use AppBundle\Field\FieldProvider;
 use AppBundle\Repository\AdventureRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -20,7 +21,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class BulkEditFormProviderTest extends \PHPUnit_Framework_TestCase
+class BulkEditFormProviderTest extends TestCase
 {
     const RELATED_ENTITY_CLASS = 'A\Related\Entity\Class';
     const EDIT_ROUTE = '/some/edit/route';
@@ -30,32 +31,32 @@ class BulkEditFormProviderTest extends \PHPUnit_Framework_TestCase
     private $formProvider;
 
     /**
-     * @var AdventureRepository|PHPUnit_Framework_MockObject_MockObject
+     * @var AdventureRepository|MockObject
      */
     private $repository;
 
     /**
-     * @var EntityManagerInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var EntityManagerInterface|MockObject
      */
     private $em;
 
     /**
-     * @var FormFactoryInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var FormFactoryInterface|MockObject
      */
     private $formFactory;
 
     /**
-     * @var RouterInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var RouterInterface|MockObject
      */
     private $router;
 
     /**
-     * @var FieldProvider|PHPUnit_Framework_MockObject_MockObject
+     * @var FieldProvider|MockObject
      */
     private $fieldProvider;
 
     /**
-     * @var FormBuilderInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var FormBuilderInterface|MockObject
      */
     private $formBuilder;
 

--- a/tests/AppBundle/Entity/AdventureTest.php
+++ b/tests/AppBundle/Entity/AdventureTest.php
@@ -9,8 +9,9 @@ use AppBundle\Entity\Monster;
 use AppBundle\Entity\Publisher;
 use AppBundle\Entity\Setting;
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
 
-class AdventureTest extends \PHPUnit_Framework_TestCase
+class AdventureTest extends TestCase
 {
     /**
      * @var Adventure

--- a/tests/AppBundle/Repository/AdventureRepositoryTest.php
+++ b/tests/AppBundle/Repository/AdventureRepositoryTest.php
@@ -288,7 +288,7 @@ class AdventureRepositoryTest extends WebTestCase
     }
 
     /**
-     * @return Field|\PHPUnit_Framework_MockObject_MockObject
+     * @return Field|\MockObject
      */
     private function relatedField(string $fieldName, string $class, bool $multiple)
     {

--- a/tests/AppBundle/Security/AdventureListVoterTest.php
+++ b/tests/AppBundle/Security/AdventureListVoterTest.php
@@ -6,12 +6,13 @@ namespace Tests\AppBundle\Security;
 use AppBundle\Entity\AdventureList;
 use AppBundle\Entity\User;
 use AppBundle\Security\AdventureListVoter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class AdventureListVoterTest extends \PHPUnit_Framework_TestCase
+class AdventureListVoterTest extends TestCase
 {
     const TOKEN_SECRET = '123';
     const LIST_ATTRIBUTE = 'list';

--- a/tests/AppBundle/Twig/AppExtensionTest.php
+++ b/tests/AppBundle/Twig/AppExtensionTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Tests\Twig;
 
 use AppBundle\Twig\AppExtension;
+use PHPUnit\Framework\TestCase;
 
-class AppExtensionTest extends \PHPUnit_Framework_TestCase
+class AppExtensionTest extends TestCase
 {
     /**
      * @var AppExtension

--- a/tests/Browser/NewAdventureTest.php
+++ b/tests/Browser/NewAdventureTest.php
@@ -44,6 +44,8 @@ class NewAdventureTest extends BrowserTestCase
         $page = $session->getPage();
         if (!$triggerValidationError) {
             $this->fillField($session, 'title', self::TITLE);
+        } else {
+            $this->disableFormValidation($session);
         }
         $page->findButton('Save')->click();
 
@@ -73,6 +75,8 @@ class NewAdventureTest extends BrowserTestCase
 
         if (!$triggerValidationError) {
             $this->fillField($session, 'title', self::TITLE);
+        } else {
+            $this->disableFormValidation($session);
         }
         $this->fillField($session, 'description', self::DESCRIPTION);
 
@@ -97,10 +101,10 @@ class NewAdventureTest extends BrowserTestCase
 
         $this->fillField($session, 'minStartingLevel', self::MIN_STARTING_LEVEL);
         $this->fillField($session, 'maxStartingLevel', self::MAX_STARTING_LEVEL);
-        $this->fillField($session, 'startingLevelRange', self::STARTING_LEVEL_RANGE);
+        $this->fillSelectizedInput($session, 'startingLevelRange', self::STARTING_LEVEL_RANGE, false);
         $this->fillField($session, 'numPages', self::NUM_PAGES);
-        $this->fillField($session, 'foundIn', self::FOUND_IN);
-        $this->fillField($session, 'partOf', self::PART_OF);
+        $this->fillSelectizedInput($session, 'foundIn', self::FOUND_IN, false);
+        $this->fillSelectizedInput($session, 'partOf', self::PART_OF, false);
         $this->fillField($session, 'link', self::LINK);
         $this->fillField($session, 'thumbnailUrl', self::THUMBNAIL_URL);
 
@@ -164,15 +168,14 @@ class NewAdventureTest extends BrowserTestCase
                 $.each(options, function (key, option) {
                     if (option.title === '{$value}') {
                         selectize.addItem(option.value);
-                        return;
+                        return; // TODO: Does this really exit the function?
                     }
                 });
                 selectize.createItem('{$value}');
             })()
         ");
         if ($isNewValue) {
-            $page = $session->getPage();
-            $page->pressButton('Add');
+            $session->getPage()->pressButton('Add');
         }
     }
 

--- a/tests/Browser/NewAdventureTest.php
+++ b/tests/Browser/NewAdventureTest.php
@@ -165,13 +165,16 @@ class NewAdventureTest extends BrowserTestCase
             (function () {
                 var selectize = $('#appbundle_adventure_{$name}')[0].selectize;
                 var options = selectize.options;
+                var found = false;
                 $.each(options, function (key, option) {
                     if (option.title === '{$value}') {
                         selectize.addItem(option.value);
-                        return; // TODO: Does this really exit the function?
+                        found = true;
                     }
                 });
-                selectize.createItem('{$value}');
+                if (!found) {
+                    selectize.createItem('{$value}');  
+                } 
             })()
         ");
         if ($isNewValue) {


### PR DESCRIPTION
I just couldn't get PhantomJS to work reliably and fast enough. Additonally, PhantomJS has officially been abandoned a few days ago: https://github.com/ariya/phantomjs/issues/15344
This is why I decided to switch to Google Chrome in headless mode. Tests run lightning fast (compared to PhantomJS) and in a real browser.
While I was at it, I also moved all the linting into a separate travis build.