### PR TITLE
Customize error pages to use our design

### DIFF
--- a/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -1,0 +1,17 @@
+{# https://symfony.com/doc/current/controller/error_pages.html#overriding-the-default-error-templates #}
+{% extends 'base.html.twig' %}
+{% block title 'Error: ' ~ status_code  ~ ' ' ~ status_text %}
+{% block body %}
+    <div id="lrf-container">
+        <div id="lrf">
+            <div class="title">{% block error_title %}Oops! An Error Occurred{% endblock %}</div>
+            <h4>The server returned "{{ status_code }} {{ status_text }}".</h4>
+            <div class="alert alert-warning">
+                {% block error_description %}
+                    Something is broken. Please let us know what you were doing when this error occurred.
+                    We will fix it as soon as possible. Sorry for any inconvenience caused.
+                {% endblock %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/Resources/TwigBundle/views/Exception/error403.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error403.html.twig
@@ -1,0 +1,3 @@
+{% extends '@Twig/Exception/error.html.twig' %}
+{% block error_title 'Insufficient Permissions' %}
+{% block error_description "You don't have permission to access this page." %}

--- a/app/Resources/TwigBundle/views/Exception/error404.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error404.html.twig
@@ -1,0 +1,3 @@
+{% extends '@Twig/Exception/error.html.twig' %}
+{% block error_title 'Page not Found' %}
+{% block error_description "The page you are looking for could not be found." %}


### PR DESCRIPTION
Here is an example of how it looks like:
![grafik](https://user-images.githubusercontent.com/2145092/39408866-413b23f2-4bdd-11e8-8ada-b6bea5306dbd.png)

Symfony Docs: https://symfony.com/doc/current/controller/error_pages.html#overriding-the-default-error-templates