### PR TITLE
Allow to sort results

### DIFF
--- a/app/Resources/views/adventures/index.html.twig
+++ b/app/Resources/views/adventures/index.html.twig
@@ -12,6 +12,7 @@
                     data-url="{{ url('adventure_index') | e("html_attr") }}"
                     data-initial-filter-values="{{ searchFilter | json_encode | e("html_attr")}}"
                     data-initial-query="{{ q | e("html_attr") }}"
+                    data-initial-sort-by="{{ sortBy | e("html_attr") }}"
                     data-field-stats="{{ stats | json_encode | e("html_attr") }}"
                 ></div>
                 <div class="adl-sidebar">

--- a/app/Resources/views/adventures/index.html.twig
+++ b/app/Resources/views/adventures/index.html.twig
@@ -13,6 +13,7 @@
                     data-initial-filter-values="{{ searchFilter | json_encode | e("html_attr")}}"
                     data-initial-query="{{ q | e("html_attr") }}"
                     data-initial-sort-by="{{ sortBy | e("html_attr") }}"
+                    data-initial-seed="{{ seed | e("html_attr") }}"
                     data-field-stats="{{ stats | json_encode | e("html_attr") }}"
                 ></div>
                 <div class="adl-sidebar">

--- a/app/Resources/views/adventures/search_results.html.twig
+++ b/app/Resources/views/adventures/search_results.html.twig
@@ -13,6 +13,10 @@
                         <div class="tag tag-level">{{ level }}</div>
                     {% endif %}
                     <div class="tag tag-length">{{ adventure.numPages }} pages</div>
+                    <div class="tag" title="Reviews">
+                        <i class="fa fa-thumbs-up"></i> {{ adventure.numPositiveReviews }}&nbsp;
+                        <i class="fa fa-thumbs-down"></i> {{ adventure.numNegativeReviews }}
+                    </div>
                 </div>
                 <p class="description">{{ adventure.description }}</p>
             </div>

--- a/app/Resources/views/api/docs.html.twig
+++ b/app/Resources/views/api/docs.html.twig
@@ -20,7 +20,7 @@
         <li><code>numPages-asc</code> Least pages</li>
         <li><code>createdAt-desc</code> Recently added</li>
         <li><code>createdAt-asc</code> Least recently added</li>
-        <li><code>random-SEED</code> Random sorting, seeded with everything that follows after the hypen. The seed can be any string, e.g. the current date. It is useful to keep the same sorting when accessing multiple pages of search results.</li>
+        <li><code>random</code> Random sorting. To seed the random generator and make pagination possible, provide a seed in the <code>seed</code> parameter. The seed can be any string, e.g. the current date.</li>
       </ul>
     </div>
     <div class="title"><a href="{{ path('api_adventure', {id: 'ADVENTURE-ID-HERE'}) }}">/api/adventure/{id}</a></div>

--- a/app/Resources/views/api/docs.html.twig
+++ b/app/Resources/views/api/docs.html.twig
@@ -10,6 +10,18 @@
     <div class="content">
       Returns a paginated list of all adventures. Use the <code>page</code> query parameter to select the page (1-indexed, default 1).
       You can use the <code>q</code> parameter to filter adventures by a search query and the <code>f</code> parameter to apply filters. To find out more about the syntax and available filters, use the normal web-based search and look at the <code>f</code> parameter in your browser's dev tools.
+
+      The <code>sortBy</code> parameter can be used to sort the adventures. Possible values are:
+      <ul>
+        <li><code>(nothing)</code>: Best matches first</li>
+        <li><code>reviews</code>: Adventures sorted by reviews</li>
+        <li><code>title</code>: Sort by title</li>
+        <li><code>numPages-desc</code> Most pages</li>
+        <li><code>numPages-asc</code> Least pages</li>
+        <li><code>createdAt-desc</code> Recently added</li>
+        <li><code>createdAt-asc</code> Least recently added</li>
+        <li><code>random-SEED</code> Random sorting, seeded with everything that follows after the hypen. The seed can be any string, e.g. the current date. It is useful to keep the same sorting when accessing multiple pages of search results.</li>
+      </ul>
     </div>
     <div class="title"><a href="{{ path('api_adventure', {id: 'ADVENTURE-ID-HERE'}) }}">/api/adventure/{id}</a></div>
     <div class="content">

--- a/app/Resources/webpack/js/adventures_filter.jsx
+++ b/app/Resources/webpack/js/adventures_filter.jsx
@@ -13,6 +13,7 @@ import { Root } from "./adventures_filter/Root";
   const url = root.dataset.url;
   const initialQuery = root.dataset.initialQuery;
   const initialSortBy = root.dataset.initialSortBy;
+  const initialSeed = root.dataset.initialSeed;
   const fieldStats = JSON.parse(root.dataset.fieldStats);
   ReactDOM.render(
     <Root
@@ -21,6 +22,7 @@ import { Root } from "./adventures_filter/Root";
       initialFilterValues={initialFilterValues}
       initialQuery={initialQuery}
       initialSortBy={initialSortBy}
+      initialSeed={initialSeed}
       fieldStats={fieldStats}
     />,
     root

--- a/app/Resources/webpack/js/adventures_filter.jsx
+++ b/app/Resources/webpack/js/adventures_filter.jsx
@@ -12,6 +12,7 @@ import { Root } from "./adventures_filter/Root";
   const initialFilterValues = JSON.parse(root.dataset.initialFilterValues);
   const url = root.dataset.url;
   const initialQuery = root.dataset.initialQuery;
+  const initialSortBy = root.dataset.initialSortBy;
   const fieldStats = JSON.parse(root.dataset.fieldStats);
   ReactDOM.render(
     <Root
@@ -19,6 +20,7 @@ import { Root } from "./adventures_filter/Root";
       url={url}
       initialFilterValues={initialFilterValues}
       initialQuery={initialQuery}
+      initialSortBy={initialSortBy}
       fieldStats={fieldStats}
     />,
     root

--- a/app/Resources/webpack/js/adventures_filter/Root.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Root.jsx
@@ -9,13 +9,29 @@ export function Root({
   url,
   initialFilterValues,
   initialQuery,
+  initialSortBy,
   fieldStats,
 }) {
   const [showMoreFilters, setShowMoreFilters] = React.useState(false);
   const [query, setQuery] = React.useState(initialQuery);
+  const [sortBy, setSortBy] = React.useState(initialSortBy);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const formRef = React.useRef(null);
 
-  const onSubmit = () => formRef.current.submit();
+  const onSubmit = () => {
+    if (!formRef.current) {
+      return;
+    }
+    setIsSubmitting(true);
+    formRef.current.submit();
+  };
+
+  // Automatically submit the form whenever sortBy changes.
+  React.useEffect(() => {
+    if (sortBy !== initialSortBy) {
+      onSubmit();
+    }
+  }, [sortBy]);
 
   return (
     <>
@@ -25,6 +41,7 @@ export function Root({
         </a>
         <form method="post" action={url} id="search-form" ref={formRef}>
           <input type="hidden" value={query} name="q" />
+          <input type="hidden" value={sortBy} name="sortBy" />
           <Filters
             fields={fields}
             showMoreFilters={showMoreFilters}
@@ -45,8 +62,11 @@ export function Root({
         <>
           <SearchBox
             query={query}
-            onSubmit={onSubmit}
             onQueryChanged={setQuery}
+            sortBy={sortBy}
+            onSortByChanged={setSortBy}
+            isSubmitting={isSubmitting}
+            onSubmit={onSubmit}
           />
           <SearchTags
             initialFilterValues={initialFilterValues}

--- a/app/Resources/webpack/js/adventures_filter/Root.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Root.jsx
@@ -10,12 +10,14 @@ export function Root({
   initialFilterValues,
   initialQuery,
   initialSortBy,
+  initialSeed,
   fieldStats,
 }) {
   const [showMoreFilters, setShowMoreFilters] = React.useState(false);
   const [query, setQuery] = React.useState(initialQuery);
   const [sortBy, setSortBy] = React.useState(initialSortBy);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [seed, setSeed] = React.useState(initialSeed);
   const formRef = React.useRef(null);
 
   const onSubmit = () => {
@@ -26,12 +28,12 @@ export function Root({
     formRef.current.submit();
   };
 
-  // Automatically submit the form whenever sortBy changes.
+  // Automatically submit the form whenever sortBy or the seed changes.
   React.useEffect(() => {
-    if (sortBy !== initialSortBy) {
+    if (sortBy !== initialSortBy || seed !== initialSeed) {
       onSubmit();
     }
-  }, [sortBy]);
+  }, [sortBy, seed]);
 
   return (
     <>
@@ -42,6 +44,7 @@ export function Root({
         <form method="post" action={url} id="search-form" ref={formRef}>
           <input type="hidden" value={query} name="q" />
           <input type="hidden" value={sortBy} name="sortBy" />
+          <input type="hidden" value={seed} name="seed" />
           <Filters
             fields={fields}
             showMoreFilters={showMoreFilters}
@@ -67,6 +70,7 @@ export function Root({
             onSortByChanged={setSortBy}
             isSubmitting={isSubmitting}
             onSubmit={onSubmit}
+            setSeed={setSeed}
           />
           <SearchTags
             initialFilterValues={initialFilterValues}

--- a/app/Resources/webpack/js/adventures_filter/SearchBox.jsx
+++ b/app/Resources/webpack/js/adventures_filter/SearchBox.jsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 const sortByOptions = [
   { title: "Best match", value: "" },
+  { title: "Reviews", value: "reviews" },
   { title: "Title", value: "title" },
   { title: "Most pages", value: "numPages-desc" },
   { title: "Least pages", value: "numPages-asc" },

--- a/app/Resources/webpack/js/adventures_filter/SearchBox.jsx
+++ b/app/Resources/webpack/js/adventures_filter/SearchBox.jsx
@@ -18,6 +18,7 @@ export function SearchBox({
   onSortByChanged,
   isSubmitting,
   onSubmit,
+  setSeed,
 }) {
   return (
     <div id="search-bar">
@@ -41,9 +42,9 @@ export function SearchBox({
           </button>
         </div>
       </div>
-      <div class="dropdown">
+      <div className="dropdown">
         <button
-          class="btn btn-outline-secondary dropdown-toggle"
+          className="btn btn-outline-secondary dropdown-toggle"
           type="button"
           id="sortButton"
           data-toggle="dropdown"
@@ -54,27 +55,37 @@ export function SearchBox({
           Sort by
         </button>
         <div
-          class="dropdown-menu dropdown-menu-right"
+          className="dropdown-menu dropdown-menu-right"
           aria-labelledby="sortButton"
         >
           {sortByOptions.map(({ title, value }) => (
             <a
-              class="dropdown-item"
-              href="javascript:void(0)"
-              onClick={() => onSortByChanged(value)}
+              key={value}
+              className="dropdown-item"
+              href="#"
+              onClick={(e) => {
+                // prevent appending '#' to the URL
+                e.preventDefault();
+                onSortByChanged(value);
+              }}
             >
               {sortBy === value && <i className="fa fa-check mr-1" />}
               {title}
             </a>
           ))}
           <a
-            class="dropdown-item"
-            href="javascript:void(0)"
-            onClick={() => onSortByChanged(`random-${Date.now()}`)}
+            className="dropdown-item"
+            href="#"
+            onClick={(e) => {
+              // prevent appending '#' to the URL
+              e.preventDefault();
+              // Set a new seed evertime this option is selected. This allows the user to continue to shuffle
+              // the adventures if they don't like the current random ordering.
+              setSeed(Date.now());
+              onSortByChanged("random");
+            }}
           >
-            {sortBy.indexOf("random-") === 0 && (
-              <i className="fa fa-check mr-1" />
-            )}
+            {sortBy === "random" && <i className="fa fa-check mr-1" />}
             Random
           </a>
         </div>

--- a/app/Resources/webpack/js/adventures_filter/SearchBox.jsx
+++ b/app/Resources/webpack/js/adventures_filter/SearchBox.jsx
@@ -1,32 +1,83 @@
 import * as React from "react";
 
-export function SearchBox({ query, onQueryChanged, onSubmit }) {
-  const [isSearching, setIsSearching] = React.useState(false);
+const sortByOptions = [
+  { title: "Best match", value: "" },
+  { title: "Title", value: "title" },
+  { title: "Most pages", value: "numPages-desc" },
+  { title: "Least pages", value: "numPages-asc" },
+  { title: "Recently added", value: "createdAt-desc" },
+  { title: "Least recently added", value: "createdAt-asc" },
+  // random is special, see below.
+];
 
-  const search = () => {
-    setIsSearching(true);
-    onSubmit(query);
-  };
-
+export function SearchBox({
+  query,
+  onQueryChanged,
+  sortBy,
+  onSortByChanged,
+  isSubmitting,
+  onSubmit,
+}) {
   return (
     <div id="search-bar">
-      <input
-        type="text"
-        id="search-query"
-        placeholder="SEARCH FOR"
-        value={query}
-        disabled={isSearching}
-        onChange={(e) => onQueryChanged(e.target.value)}
-        onKeyPress={(key) => key.which === 13 && search()}
-      />
-      <button
-        id="search-submit"
-        className="btn btn-primary"
-        disabled={isSearching}
-        onClick={() => search()}
-      >
-        Search
-      </button>
+      <div className="input-group mr-2">
+        <input
+          type="text"
+          className="form-control"
+          placeholder="SEARCH FOR"
+          value={query}
+          disabled={isSubmitting}
+          onChange={(e) => onQueryChanged(e.target.value)}
+          onKeyPress={(key) => key.which === 13 && onSubmit()}
+        />
+        <div className="input-group-append">
+          <button
+            className="btn btn-primary"
+            disabled={isSubmitting}
+            onClick={() => onSubmit()}
+          >
+            Search
+          </button>
+        </div>
+      </div>
+      <div class="dropdown">
+        <button
+          class="btn btn-outline-secondary dropdown-toggle"
+          type="button"
+          id="sortButton"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+          disabled={isSubmitting}
+        >
+          Sort by
+        </button>
+        <div
+          class="dropdown-menu dropdown-menu-right"
+          aria-labelledby="sortButton"
+        >
+          {sortByOptions.map(({ title, value }) => (
+            <a
+              class="dropdown-item"
+              href="javascript:void(0)"
+              onClick={() => onSortByChanged(value)}
+            >
+              {sortBy === value && <i className="fa fa-check mr-1" />}
+              {title}
+            </a>
+          ))}
+          <a
+            class="dropdown-item"
+            href="javascript:void(0)"
+            onClick={() => onSortByChanged(`random-${Date.now()}`)}
+          >
+            {sortBy.indexOf("random-") === 0 && (
+              <i className="fa fa-check mr-1" />
+            )}
+            Random
+          </a>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/Resources/webpack/sass/_adventures.scss
+++ b/app/Resources/webpack/sass/_adventures.scss
@@ -31,18 +31,8 @@ $thumbnail-height: 100px;
   display: flex;
   margin-bottom: $element-margin-bottom;
 
-  > * { margin-right: 4px; }
-  > *:last-child { margin-right: 0; }
-
-  #search-query {
-    @extend .form-control;
-
-    flex-grow: 8;
+  button, input {
     font-size: 1.2rem;
-  }
-
-  #search-submit {
-    cursor: pointer;
   }
 }
 

--- a/src/AppBundle/Command/AppElasticsearchReindexCommand.php
+++ b/src/AppBundle/Command/AppElasticsearchReindexCommand.php
@@ -119,6 +119,8 @@ class AppElasticsearchReindexCommand extends Command
             'handouts' => self::FIELD_BOOLEAN,
 
             'createdAt' => self::FIELD_DATE,
+            'numPositiveReviews' => self::FIELD_INTEGER,
+            'numNegativeReviews' => self::FIELD_INTEGER,
         ];
 
         $client->indices()->putMapping([

--- a/src/AppBundle/Command/AppElasticsearchReindexCommand.php
+++ b/src/AppBundle/Command/AppElasticsearchReindexCommand.php
@@ -68,6 +68,9 @@ class AppElasticsearchReindexCommand extends Command
     const FIELD_BOOLEAN = [
         'type' => 'boolean',
     ];
+    const FIELD_DATE = [
+        'type' => 'date'
+    ];
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -114,6 +117,8 @@ class AppElasticsearchReindexCommand extends Command
             'pregeneratedCharacters' => self::FIELD_BOOLEAN,
             'tacticalMaps' => self::FIELD_BOOLEAN,
             'handouts' => self::FIELD_BOOLEAN,
+
+            'createdAt' => self::FIELD_DATE,
         ];
 
         $client->indices()->putMapping([

--- a/src/AppBundle/Controller/AdventureController.php
+++ b/src/AppBundle/Controller/AdventureController.php
@@ -39,8 +39,17 @@ class AdventureController extends Controller
      */
     public function indexAction(Request $request, AdventureSearch $adventureSearch, FieldProvider $fieldProvider)
     {
-        list($q, $filters, $page, $sortBy) = $adventureSearch->requestToSearchParams($request);
-        list($adventures, $totalNumberOfResults, $hasMoreResults, $stats) = $adventureSearch->search($q, $filters, $page, $sortBy);
+        list($q, $filters, $page, $sortBy, $seed) = $adventureSearch->requestToSearchParams($request);
+        list($adventures, $totalNumberOfResults, $hasMoreResults, $stats) = $adventureSearch->search(
+            $q,
+            $filters,
+            $page,
+            // Sort randomly unless there is a search query or $sortBy is not set to 'Best match'
+            // Deliberately NOT alter the $sortBy variable as passed to the template below, since
+            // the user should still see 'Best match' as selected in the sort-by dropdown.
+            '' === $q && '' === $sortBy ? 'random' : $sortBy,
+            $seed
+        );
 
         return $this->render('adventures/index.html.twig', [
             'adventures' => $adventures,
@@ -51,7 +60,8 @@ class AdventureController extends Controller
             'searchFilter' => $filters,
             'fields' => $fieldProvider->getFields(),
             'q' => $q,
-            'sortBy' => $sortBy
+            'sortBy' => $sortBy,
+            'seed' => $seed
         ]);
     }
 

--- a/src/AppBundle/Controller/AdventureController.php
+++ b/src/AppBundle/Controller/AdventureController.php
@@ -40,16 +40,17 @@ class AdventureController extends Controller
     public function indexAction(Request $request, AdventureSearch $adventureSearch, FieldProvider $fieldProvider)
     {
         $q = $request->get('q', '');
+        $sortBy = $request->get('sortBy', '');
         $page = (int)$request->get('page', 1);
         $filters = $request->get('f', []);
         if (!is_array($filters)) {
             $filters = [];
         }
         $fields = $fieldProvider->getFields();
-        list($paginatedAdventureDocuments, $totalNumberOfResults, $hasMoreResults, $stats) = $adventureSearch->search($q, $filters, $page);
+        list($adventures, $totalNumberOfResults, $hasMoreResults, $stats) = $adventureSearch->search($q, $filters, $page, $sortBy);
 
         return $this->render('adventures/index.html.twig', [
-            'adventures' => $paginatedAdventureDocuments,
+            'adventures' => $adventures,
             'totalNumberOfResults' => $totalNumberOfResults,
             'hasMoreResults' => $hasMoreResults,
             'page' => $page,
@@ -57,6 +58,7 @@ class AdventureController extends Controller
             'searchFilter' => $filters,
             'fields' => $fields,
             'q' => $q,
+            'sortBy' => $sortBy
         ]);
     }
 

--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -31,8 +31,8 @@ class ApiController extends Controller
      */
     public function indexAction(Request $request, AdventureSearch $adventureSearch, Serializer $serializer)
     {
-        list($q, $filters, $page, $sortBy) = $adventureSearch->requestToSearchParams($request);
-        list($adventures, $totalNumberOfResults) = $adventureSearch->search($q, $filters, $page, $sortBy);
+        list($q, $filters, $page, $sortBy, $seed) = $adventureSearch->requestToSearchParams($request);
+        list($adventures, $totalNumberOfResults) = $adventureSearch->search($q, $filters, $page, $sortBy, $seed);
 
         return new JsonResponse([
             "total_count" => $totalNumberOfResults,

--- a/src/AppBundle/Entity/AdventureDocument.php
+++ b/src/AppBundle/Entity/AdventureDocument.php
@@ -11,6 +11,9 @@ class AdventureDocument
 
     private $slug;
 
+    /**
+     * @var float|null
+     */
     private $score;
 
     /**
@@ -143,7 +146,7 @@ class AdventureDocument
         bool $pregeneratedCharacters = null,
         bool $tacticalMaps = null,
         bool $handouts = null,
-        float $score = 0.0)
+        float $score = null)
     {
         $this->id = $id;
         $this->authors = $authors;
@@ -225,7 +228,7 @@ class AdventureDocument
     /**
      * @return float
      */
-    public function getScore(): float
+    public function getScore()
     {
         return $this->score;
     }

--- a/src/AppBundle/Entity/AdventureDocument.php
+++ b/src/AppBundle/Entity/AdventureDocument.php
@@ -121,6 +121,16 @@ class AdventureDocument
      */
     private $partOf;
 
+    /**
+     * @var int
+     */
+    private $numPositiveReviews;
+
+    /**
+     * @var int
+     */
+    private $numNegativeReviews;
+
     public function __construct(
         int $id,
         array $authors,
@@ -146,6 +156,8 @@ class AdventureDocument
         bool $pregeneratedCharacters = null,
         bool $tacticalMaps = null,
         bool $handouts = null,
+        int $numPositiveReviews = 0,
+        int $numNegativeReviews = 0,
         float $score = null)
     {
         $this->id = $id;
@@ -173,6 +185,8 @@ class AdventureDocument
         $this->pregeneratedCharacters = $pregeneratedCharacters;
         $this->tacticalMaps = $tacticalMaps;
         $this->handouts = $handouts;
+        $this->numPositiveReviews = $numPositiveReviews;
+        $this->numNegativeReviews = $numNegativeReviews;
     }
 
     /**
@@ -205,7 +219,9 @@ class AdventureDocument
             $adventure->isSoloable(),
             $adventure->hasPregeneratedCharacters(),
             $adventure->hasTacticalMaps(),
-            $adventure->hasHandouts()
+            $adventure->hasHandouts(),
+            $adventure->getNumberOfThumbsUp(),
+            $adventure->getNumberOfThumbsDown()
         );
     }
 
@@ -407,6 +423,22 @@ class AdventureDocument
     public function getPartOf()
     {
         return $this->partOf;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getNumPositiveReviews()
+    {
+        return $this->numPositiveReviews;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getNumNegativeReviews()
+    {
+        return $this->numNegativeReviews;
     }
 
     /**

--- a/src/AppBundle/Listener/SearchIndexUpdater.php
+++ b/src/AppBundle/Listener/SearchIndexUpdater.php
@@ -5,6 +5,7 @@ namespace AppBundle\Listener;
 
 use AppBundle\Entity\Adventure;
 use AppBundle\Entity\RelatedEntityInterface;
+use AppBundle\Entity\Review;
 use AppBundle\Service\AdventureSerializer;
 use AppBundle\Service\ElasticSearch;
 use Doctrine\Common\EventSubscriber;
@@ -172,6 +173,9 @@ class SearchIndexUpdater implements EventSubscriber
         }
         if ($entity instanceof RelatedEntityInterface) {
             return $entity->getAdventures();
+        }
+        if ($entity instanceof Review) {
+            return [$entity->getAdventure()];
         }
 
         return [];

--- a/src/AppBundle/Service/AdventureSerializer.php
+++ b/src/AppBundle/Service/AdventureSerializer.php
@@ -37,6 +37,7 @@ class AdventureSerializer
     {
         $doc= [];
         $doc['slug'] = $adventure->getSlug();
+        $doc['createdAt'] = $adventure->getCreatedAt()->format('c');
 
         foreach ($this->fieldProvider->getFields() as $field) {
             $value = $this->propertyAccessor->getValue(

--- a/src/AppBundle/Service/AdventureSerializer.php
+++ b/src/AppBundle/Service/AdventureSerializer.php
@@ -38,6 +38,8 @@ class AdventureSerializer
         $doc= [];
         $doc['slug'] = $adventure->getSlug();
         $doc['createdAt'] = $adventure->getCreatedAt()->format('c');
+        $doc['positiveReviews'] = $adventure->getNumberOfThumbsUp();
+        $doc['negativeReviews'] = $adventure->getNumberOfThumbsDown();
 
         foreach ($this->fieldProvider->getFields() as $field) {
             $value = $this->propertyAccessor->getValue(

--- a/src/AppBundle/Service/TimeProvider.php
+++ b/src/AppBundle/Service/TimeProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AppBundle\Service;
+
+class TimeProvider
+{
+    /**
+     * @return int The current time in milliseconds.
+     */
+    public function millis()
+    {
+        return (int)round(microtime(true) * 1000);
+    }
+}

--- a/tests/AppBundle/Service/AdventureSearchTest.php
+++ b/tests/AppBundle/Service/AdventureSearchTest.php
@@ -6,6 +6,7 @@ namespace Tests\AppBundle\Service;
 use AppBundle\Field\FieldProvider;
 use AppBundle\Service\AdventureSearch;
 use AppBundle\Service\ElasticSearch;
+use AppBundle\Service\TimeProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,35 +28,45 @@ class AdventureSearchTest extends TestCase
      */
     private $elasticSearch;
 
+    /**
+     * @var TimeProvider|MockObject
+     */
+    private $timeProvider;
+
     public function setUp()
     {
         $this->fieldProvider = $this->createMock(FieldProvider::class);
         $this->elasticSearch = $this->createMock(ElasticSearch::class);
-        $this->search = new AdventureSearch($this->fieldProvider, $this->elasticSearch);
+        $this->timeProvider = $this->createMock(TimeProvider::class);
+        $this->timeProvider->method('millis')->willReturn(123);
+        $this->search = new AdventureSearch($this->fieldProvider, $this->elasticSearch, $this->timeProvider);
     }
 
     public function testRequestToSearchParams()
     {
         $request = Request::create("");
-        $this->assertEquals(["", [], 1, ""], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["", [], 1, "", "123"], $this->search->requestToSearchParams($request));
 
         $request = Request::create("/?page=10");
-        $this->assertEquals(["", [], 10, ""], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["", [], 10, "", "123"], $this->search->requestToSearchParams($request));
 
         $request = Request::create("/?q=foo");
-        $this->assertEquals(["foo", [], 1, ""], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["foo", [], 1, "", "123"], $this->search->requestToSearchParams($request));
 
         $request = Request::create("/?f[edition][v]=DND&f[numPages][min]=2");
         $this->assertEquals(["", [
             "edition" => ["v" => "DND"],
             "numPages" => ["min" => "2"]
-        ], 1, ""], $this->search->requestToSearchParams($request));
+        ], 1, "", "123"], $this->search->requestToSearchParams($request));
 
         // Invalid filter should not break anything
         $request = Request::create("/?f=2");
-        $this->assertEquals(["", [], 1, ""], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["", [], 1, "", "123"], $this->search->requestToSearchParams($request));
 
         $request = Request::create("/?sortBy=title");
-        $this->assertEquals(["", [], 1, "title"], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["", [], 1, "title", "123"], $this->search->requestToSearchParams($request));
+
+        $request = Request::create("/?seed=foo");
+        $this->assertEquals(["", [], 1, "", "foo"], $this->search->requestToSearchParams($request));
     }
 }

--- a/tests/AppBundle/Service/AdventureSearchTest.php
+++ b/tests/AppBundle/Service/AdventureSearchTest.php
@@ -37,22 +37,25 @@ class AdventureSearchTest extends TestCase
     public function testRequestToSearchParams()
     {
         $request = Request::create("");
-        $this->assertEquals(["", [], 1], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["", [], 1, ""], $this->search->requestToSearchParams($request));
 
         $request = Request::create("/?page=10");
-        $this->assertEquals(["", [], 10], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["", [], 10, ""], $this->search->requestToSearchParams($request));
 
         $request = Request::create("/?q=foo");
-        $this->assertEquals(["foo", [], 1], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["foo", [], 1, ""], $this->search->requestToSearchParams($request));
 
         $request = Request::create("/?f[edition][v]=DND&f[numPages][min]=2");
         $this->assertEquals(["", [
             "edition" => ["v" => "DND"],
             "numPages" => ["min" => "2"]
-        ], 1], $this->search->requestToSearchParams($request));
+        ], 1, ""], $this->search->requestToSearchParams($request));
 
         // Invalid filter should not break anything
         $request = Request::create("/?f=2");
-        $this->assertEquals(["", [], 1], $this->search->requestToSearchParams($request));
+        $this->assertEquals(["", [], 1, ""], $this->search->requestToSearchParams($request));
+
+        $request = Request::create("/?sortBy=title");
+        $this->assertEquals(["", [], 1, "title"], $this->search->requestToSearchParams($request));
     }
 }

--- a/tests/AppBundle/Service/AdventureSerializerTest.php
+++ b/tests/AppBundle/Service/AdventureSerializerTest.php
@@ -22,6 +22,8 @@ class AdventureSerializerTest extends \PHPUnit_Framework_TestCase
     const AUTHOR_1 = 'an author 1';
     const AUTHOR_2 = 'an author 2';
     const PUBLISHER = 'a publisher';
+    const NUM_POSITIVE_REVIEWS = 34;
+    const NUM_NEGATIVE_REVIEWS = 8;
 
     /**
      * @var AdventureSerializer
@@ -33,21 +35,30 @@ class AdventureSerializerTest extends \PHPUnit_Framework_TestCase
      */
     private $fieldProvider;
 
+    private $CREATED_AT;
+
     public function setUp()
     {
         $this->fieldProvider = $this->createMock(FieldProvider::class);
         $this->serializer = new AdventureSerializer($this->fieldProvider);
+        $this->CREATED_AT = new \DateTime();
     }
 
-    public function testAlwaysSerializesSlug()
+    public function testAlwaysSerializesSlugCreatedAtAndNumberOfReviews()
     {
         $this->fieldProvider->method('getFields')->willReturn(new ArrayCollection([]));
         $adventure = $this->createMock(Adventure::class);
         $adventure->method('getSlug')->willReturn(self::SLUG);
+        $adventure->method('getCreatedAt')->willReturn($this->CREATED_AT);
+        $adventure->method('getNumberOfThumbsUp')->willReturn(self::NUM_POSITIVE_REVIEWS);
+        $adventure->method('getNumberOfThumbsDown')->willReturn(self::NUM_NEGATIVE_REVIEWS);
 
         $doc = $this->serializer->toElasticDocument($adventure);
         $this->assertSame([
             'slug' => self::SLUG,
+            'createdAt' => $this->CREATED_AT->format("c"),
+            'positiveReviews' => self::NUM_POSITIVE_REVIEWS,
+            'negativeReviews' => self::NUM_NEGATIVE_REVIEWS,
         ], $doc);
     }
 
@@ -64,6 +75,9 @@ class AdventureSerializerTest extends \PHPUnit_Framework_TestCase
         $adventure = $this->createMock(Adventure::class);
         $adventure->method('getTitle')->willReturn(self::TITLE);
         $adventure->method('getSlug')->willReturn(self::SLUG);
+        $adventure->method('getCreatedAt')->willReturn($this->CREATED_AT);
+        $adventure->method('getNumberOfThumbsUp')->willReturn(self::NUM_POSITIVE_REVIEWS);
+        $adventure->method('getNumberOfThumbsDown')->willReturn(self::NUM_NEGATIVE_REVIEWS);
         $adventure->method('getMinStartingLevel')->willReturn(self::MIN_STARTING_LEVEL);
         $adventure->method('hasTacticalMaps')->willReturn(self::TACTICAL_MAPS);
         $adventure->method('getLink')->willReturn(self::LINK);
@@ -71,6 +85,9 @@ class AdventureSerializerTest extends \PHPUnit_Framework_TestCase
         $doc = $this->serializer->toElasticDocument($adventure);
         $this->assertSame([
             'slug' => self::SLUG,
+            'createdAt' => $this->CREATED_AT->format("c"),
+            'positiveReviews' => self::NUM_POSITIVE_REVIEWS,
+            'negativeReviews' => self::NUM_NEGATIVE_REVIEWS,
             'title' => self::TITLE,
             'link' => self::LINK,
             'foundIn' => null,
@@ -97,6 +114,9 @@ class AdventureSerializerTest extends \PHPUnit_Framework_TestCase
         $adventure = $this->createMock(Adventure::class);
         $adventure->method('getTitle')->willReturn(self::TITLE);
         $adventure->method('getSlug')->willReturn(self::SLUG);
+        $adventure->method('getCreatedAt')->willReturn($this->CREATED_AT);
+        $adventure->method('getNumberOfThumbsUp')->willReturn(self::NUM_POSITIVE_REVIEWS);
+        $adventure->method('getNumberOfThumbsDown')->willReturn(self::NUM_NEGATIVE_REVIEWS);
         $adventure->method('getAuthors')->willReturn(
             new ArrayCollection([$author1, $author2])
         );
@@ -108,6 +128,9 @@ class AdventureSerializerTest extends \PHPUnit_Framework_TestCase
         $doc = $this->serializer->toElasticDocument($adventure);
         $this->assertSame([
             'slug' => self::SLUG,
+            'createdAt' => $this->CREATED_AT->format("c"),
+            'positiveReviews' => self::NUM_POSITIVE_REVIEWS,
+            'negativeReviews' => self::NUM_NEGATIVE_REVIEWS,
             'title' => self::TITLE,
             'authors' => [self::AUTHOR_1, self::AUTHOR_2],
             'publisher' => self::PUBLISHER,

--- a/tests/AppBundle/Service/TimeProviderTest.php
+++ b/tests/AppBundle/Service/TimeProviderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\AppBundle\Service;
+
+use AppBundle\Service\TimeProvider;
+use PHPUnit\Framework\TestCase;
+
+class TimeProviderTest extends TestCase
+{
+    public function testMillis()
+    {
+        $timeProvider = new TimeProvider();
+
+        $now = time() * 1000;
+        $result = $timeProvider->millis();
+        $this->assertTrue(is_int($result));
+        $this->assertGreaterThan($now - 1000, $result);
+        $this->assertLessThan($now + 1000, $result);
+    }
+}


### PR DESCRIPTION
This PR allows sorting results like requested in #179.
The new 'Sort by' dropdown allows sorting by
- Best match: default ElasticSearch sorting/scoring based on queries and filter
- Reviews: Wilson-Score of the positive and negative reviews. For an explanation of the scoring, you can read [this section](https://github.com/msn0/wilson-score-interval#less-technical).
- Most and least pages
- Recently and least recently added
- Random

![image](https://user-images.githubusercontent.com/2145092/81842429-4a9bd080-954c-11ea-889b-788f02e82783.png)


<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/307"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/f6d09b2794812270b520b3b71f4713858269c472.svg" /></a>

