### PR TITLE
Add global announcement bar

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -15,9 +15,18 @@
         <meta name="theme-color" content="#ffffff">
     </head>
     <body>
-        {% block header %}
-            {% include 'header.html.twig' %}
-        {% endblock %}
+        <div id="adl-announcement">
+            {% if announcement|default is not empty %}
+                <div class="announcement-bar">
+                    {{announcement}}
+                </div>
+            {% endif %}
+            <div class="header-container">
+                {% block header %}
+                    {% include 'header.html.twig' %}
+                {% endblock %}
+            </div>
+        </div>
 
         {% if app.session.flashbag.peekAll is not empty %}
             <div class="container mt-5">

--- a/app/Resources/webpack/sass/_announcement.scss
+++ b/app/Resources/webpack/sass/_announcement.scss
@@ -1,0 +1,15 @@
+#adl-announcement {
+  .announcement-bar {
+      text-align: center;
+      color: white;
+      padding: 5px;
+      font-size: 1.2rem;
+      background-color: #911313;
+      box-shadow: 4px 2px 2px #aaa;
+      margin-bottom: 5px;
+  }
+
+  .header-container {
+      position: relative;
+  }
+}

--- a/app/Resources/webpack/sass/style.scss
+++ b/app/Resources/webpack/sass/style.scss
@@ -18,6 +18,7 @@
 @import 'tags';
 @import 'filter';
 @import 'general';
+@import 'announcement';
 @import 'header';
 @import 'login_register_forgot';
 @import 'profile';

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -49,6 +49,7 @@ twig:
         - 'form_layout.html.twig'
     globals:
         google_analytics_code: '%google_analytics_code%'
+        announcement: '%announcement%'
 
 # Doctrine Configuration
 doctrine:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -39,3 +39,4 @@ parameters:
     #       code:    '123abc'
 
     affiliate_mappings: []
+    announcement: ~


### PR DESCRIPTION
Adds a bar for global announcements. The text is defined by the `announcement` parameter in `app/config/parameters.yml`.

I'm not familiar with the framework, so please let me know if anything isn't quite how it's supposed to be :)

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/319"><img src="https://gitpod.io/api/apps/github/pbs/github.com/wetterlicht/AdventureLookup.git/056e5fc3a63710d95d82699c0f2d2857d56d5775.svg" /></a>

