### PR TITLE
Minor stylistic improvements to adventure details page

### DIFF
--- a/app/Resources/views/adventure/_details.html.twig
+++ b/app/Resources/views/adventure/_details.html.twig
@@ -29,13 +29,13 @@
 
     <div class="container">
         <div class="detail-row">
-            <div class="col">
+            <div class="col-4">
                 <div class="label">Written By</div>
                 {% for author in adventure.authors %}
                     {{ macros.search('authors', author.name, author.name) }}{{ not loop.last ? ', ' : '' }}
                 {% endfor %}
             </div>
-            <div class="col">
+            <div class="col-4">
                 <div class="label">Published By</div>
                 {% if adventure.publisher %}
                     {{ macros.search('publisher', adventure.publisher.name) }}
@@ -43,7 +43,7 @@
                     Unknown
                 {% endif %}
             </div>
-            <div class="col">
+            <div class="col-4">
                 <div class="label">Publication Year</div>
                 {% if adventure.year %}
                     {{ macros.search('year', adventure.year, null, true) }}
@@ -51,7 +51,9 @@
                     Unknown
                 {% endif %}
             </div>
-            <div class="col">
+        </div>
+        <div class="detail-row">
+            <div class="col-5 col-md-6">
                 <div class="label">Setting</div>
                 {% if adventure.setting %}
                     {{ macros.search('setting', adventure.setting.name) }}
@@ -59,53 +61,54 @@
                     Unknown
                 {% endif %}
             </div>
-        </div>
-
-        <div class="detail-row">
-            <div class="col">
+            <div class="col-7 col-md-6">
                 <div class="label">Environments</div>
                 {% for environment in adventure.environments %}
                     {{ macros.search('environments', environment.name) }}{{ not loop.last ? ', ' : '' }}
                 {% endfor %}
             </div>
-            <div class="col-7">
+            <div class="col-12">
                 <div class="label">Link</div>
                 <a href="{{ adventure.link|add_affiliate_code|e('html_attr') }}">{{ adventure.link|add_affiliate_code }}</a>
             </div>
         </div>
 
         <div class="detail-row">
-            <div class="col-3">
+            <div class="col-4 col-md">
                 <div class="label">Handouts?</div>
                 {{ macros.search('handouts', adventure.handouts, adventure.handouts|bool2str) }}
             </div>
-            <div class="col-3">
+            <div class="col-4 col-md">
                 <div class="label">Battle Mats?</div>
                 {{ macros.search('tacticalMaps', adventure.tacticalMaps, adventure.tacticalMaps|bool2str) }}
             </div>
-            <div class="col-3">
-                <div class="label">Soloable?</div>
-                {{ macros.search('soloable', adventure.soloable, adventure.soloable|bool2str) }}
-            </div>
-            <div class="col-3">
+            <div class="col-4 col-md">
                 <div class="label">Includes Characters?</div>
                 {{ macros.search('pregeneratedCharacters', adventure.pregeneratedCharacters, adventure.pregeneratedCharacters|bool2str) }}
+            </div>
+            <div class="col-6 col-md">
+                <div class="label">Level</div>
+                    <span class="level">{{ format_level(adventure)|default('Unknown party level') }}</span>
+            </div>
+            <div class="col-6 col-md">
+                <div class="label">Soloable?</div>
+                {{ macros.search('soloable', adventure.soloable, adventure.soloable|bool2str) }}
             </div>
         </div>
 
         <div class="detail-row">
-            <div>
+            <div class="col-6">
                 <div class="label">Found In</div>
                 {{ macros.search('foundIn', adventure.foundIn) }}
             </div>
-            <div>
+            <div class="col-6">
                 <div class="label">Part Of</div>
                 {{ macros.search('partOf', adventure.partOf) }}
             </div>
         </div>
 
         <div class="detail-row">
-            <div class="col-xs-12 col-sm-6 col-lg">
+            <div class="col-12 col-sm-6 col-lg">
                 <div class="label">Boss Monsters and Villains</div>
                 <ul>
                     {% for monster in adventure.bossMonsters %}
@@ -118,7 +121,7 @@
                     {% endfor %}
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-6 col-lg">
+            <div class="col-12 col-sm-6 col-lg">
                 <div class="label">Common Monsters</div>
                 <ul>
                     {% for monster in adventure.commonMonsters %}
@@ -131,7 +134,7 @@
                     {% endfor %}
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-12 col-lg">
+            <div class="col-12 col-lg">
                 <div class="label">Notable Items</div>
                 <ul>
                     {% for item in adventure.items %}

--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -32,13 +32,13 @@
                     {% if app.user %}
                         <div class="row">
                             <div class="col-sm-6 col-md-4 col-lg-12">
-                                <div class="dropdown" id="adventure_list-bookmark-menu">
+                                <div class="dropdown " id="adventure_list-bookmark-menu">
                                     <a href="#" class="btn btn-secondary dropdown-toggle" id="adventure_list-bookmark-menu-btn" data-toggle="dropdown"
-                                       aria-haspopup="true" aria-expanded="false">
+                                       aria-haspopup="true" aria-expanded="false" data-display="static">
                                         <i class="fa fa-bookmark"></i> Bookmark
                                     </a>
 
-                                    <div class="dropdown-menu" aria-labelledby="adventure_list-bookmark-menu-btn">
+                                    <div class="dropdown-menu dropdown-menu-right dropdown-menu-sm-left dropdown-menu-lg-right" aria-labelledby="adventure_list-bookmark-menu-btn">
                                         <h6 class="dropdown-header">Your Lists</h6>
                                         {% for list in lists %}
                                             <button class="dropdown-item" type="button"

--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -32,7 +32,7 @@
                     {% if app.user %}
                         <div class="row">
                             <div class="col-sm-6 col-md-4 col-lg-12">
-                                <div class="dropdown " id="adventure_list-bookmark-menu">
+                                <div class="dropdown" id="adventure_list-bookmark-menu">
                                     <a href="#" class="btn btn-secondary dropdown-toggle" id="adventure_list-bookmark-menu-btn" data-toggle="dropdown"
                                        aria-haspopup="true" aria-expanded="false" data-display="static">
                                         <i class="fa fa-bookmark"></i> Bookmark

--- a/app/Resources/webpack/sass/_adventure.scss
+++ b/app/Resources/webpack/sass/_adventure.scss
@@ -66,6 +66,10 @@ $thumbnail-height: 100px;
         color: $adl-grey-light;
       }
 
+      .level {
+          text-transform: capitalize;
+      }
+
       ul {
         padding-left: 30px;
         margin-bottom: 0;


### PR DESCRIPTION
I made the alignment of the bookmark dropdown depending on the screen size, as on tablets the button is to the left.

I implemented the rows/columns as suggested and I think it looks good on mobile. Not quite sure if its a bit too empty now on bigger screens but I think semantically the rows make sense like this.

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/334"><img src="https://gitpod.io/api/apps/github/pbs/github.com/wetterlicht/AdventureLookup.git/cf21623ae820305c387df41b69737336b4ee0d43.svg" /></a>

