### PR TITLE
Generate unique titles for random adventures

### DIFF
--- a/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
+++ b/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
@@ -73,7 +73,7 @@ class RandomAdventureData implements FixtureInterface, ContainerAwareInterface, 
         for ($i = 0; $i < 200; $i++) {
             $adventure = new Adventure();
             $adventure
-                ->setTitle($faker->catchPhrase)
+                ->setTitle($faker->unique->catchPhrase)
                 ->setDescription($faker->realText(2000))
                 ->setNumPages($faker->numberBetween(1, 200))
                 ->setFoundIn($faker->catchPhrase)


### PR DESCRIPTION
This fixes an issue where creating the random adventure data would sometimes fail if the same title is generated twice (the title column has a unique index in the database).

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/335"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/b481bed56a561a0e13cf1983b161b4789a1aa8a7.svg" /></a>

