### PR TITLE
Filter button sizes and review button placement changes

### DIFF
--- a/app/Resources/views/adventure/_reviews.html.twig
+++ b/app/Resources/views/adventure/_reviews.html.twig
@@ -13,6 +13,16 @@
         {{ form_widget(review_form.rating) }}
         {{ form_widget(review_form.comment) }}
         {{ form_end(review_form) }}
+        <div>
+            <a href="javascript:void(0)" class="btn btn-primary d-none" role="button" id="confirm-review-btn">
+                <i class="fa fa-check"></i>
+                Save Review
+            </a>
+            <a href="javascript:void(0)" class="btn btn-secondary d-none pull-right" role="button" id="cancel-review-btn">
+                <i class="fa fa-times"></i>
+                Cancel
+            </a>
+        </div>
     </div>
 {% endif %}
 

--- a/app/Resources/views/adventure/index.html.twig
+++ b/app/Resources/views/adventure/index.html.twig
@@ -109,14 +109,6 @@
                             <i class="fa fa-star"></i>
                             {{ adventure.reviewBy(app.user) ? 'Edit' : 'Add' }} Your Review
                         </a>
-                        <a href="javascript:void(0)" class="btn btn-primary d-none" role="button" id="confirm-review-btn">
-                            <i class="fa fa-check"></i>
-                            Save Review
-                        </a>
-                        <a href="javascript:void(0)" class="btn btn-secondary d-none" role="button" id="cancel-review-btn">
-                            <i class="fa fa-times"></i>
-                            Cancel
-                        </a>
                     {% endif %}
                 </div>
             </div>

--- a/app/Resources/webpack/sass/_adventure.scss
+++ b/app/Resources/webpack/sass/_adventure.scss
@@ -141,6 +141,5 @@ $thumbnail-height: 100px;
     font: 1.2rem 'Roboto Condensed';
     text-transform: uppercase; 
     margin: 0 1%;
-    // box-shadow: $adl-box-shadow;
   }
 }

--- a/app/Resources/webpack/sass/_adventure.scss
+++ b/app/Resources/webpack/sass/_adventure.scss
@@ -140,6 +140,6 @@ $thumbnail-height: 100px;
     border-radius: 0;
     font: 1.2rem 'Roboto Condensed';
     text-transform: uppercase; 
-    margin: 0 1%;
+    margin: 0 1.8rem;
   }
 }

--- a/app/Resources/webpack/sass/_adventure.scss
+++ b/app/Resources/webpack/sass/_adventure.scss
@@ -133,4 +133,14 @@ $thumbnail-height: 100px;
     border-top: 1px solid $adl-grey-lightest;
     padding: $adl-card-padding-side;
   }
+  
+  .btn {
+    width: 35%;
+    padding: 8px 10px;
+    border-radius: 0;
+    font: 1.2rem 'Roboto Condensed';
+    text-transform: uppercase; 
+    margin: 0 1%;
+    // box-shadow: $adl-box-shadow;
+  }
 }

--- a/app/Resources/webpack/sass/_filter.scss
+++ b/app/Resources/webpack/sass/_filter.scss
@@ -73,7 +73,6 @@
     }
 
     &.show-more, &.show-less, &.apply {
-      padding: $adl-filter-padding-top/2;
       justify-content: space-around;
       font-size: .9rem;
     }


### PR DESCRIPTION
Adjust filter buttons, move review save and cancel buttons inside review form. 
* Making the filter buttons marginally larger to accommodate easier mobile use without hitting filter when you meant to see more and vice-versa
* Move review buttons inside review form so that save and cancel buttons are more intuitively placed, especially on mobile.

Filters:
OLD: 
![image](https://user-images.githubusercontent.com/3180645/82759024-8f730300-9da7-11ea-96b9-aa891f8f45fa.png)

NEW:
![image](https://user-images.githubusercontent.com/3180645/82759033-a6195a00-9da7-11ea-9129-e6c539622f7e.png)


Reviews:
OLD:
![image](https://user-images.githubusercontent.com/3180645/82758999-53d83900-9da7-11ea-84da-d395215604b2.png)

NEW:
![image](https://user-images.githubusercontent.com/3180645/82758988-3905c480-9da7-11ea-8984-3e04cd25b581.png)


<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/342"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Wigginns/AdventureLookup.git/dd455284e1692aae23913f7469f941d297290fc9.svg" /></a>

