### PR TITLE
Remove trailing slash on /adventures route

### DIFF
--- a/src/AppBundle/Controller/AdventureController.php
+++ b/src/AppBundle/Controller/AdventureController.php
@@ -29,8 +29,8 @@ class AdventureController extends Controller
     /**
      * Lists all adventure entities.
      *
-     * @Route("/adventures/", name="adventure_index")
-     * @Method({"GET", "POST"})
+     * @Route("/adventures", name="adventure_index")
+     * @Method("GET")
      *
      * @return Response
      */
@@ -60,6 +60,27 @@ class AdventureController extends Controller
             'sortBy' => $sortBy,
             'seed' => $seed,
         ]);
+    }
+
+    /**
+     * Redirect from route with trailing slash to route without trailing slash.
+     * Based on https://symfony.com/doc/3.4/routing/redirect_trailing_slash.html
+     *
+     * TODO: Remove in Symfony 4.x (https://symfony.com/doc/4.4/routing.html#redirecting-urls-with-trailing-slashes)
+     *
+     * @Route("/adventures/")
+     * @Method("GET")
+     */
+    public function redirectFromURLWithTrailingSlashAction(Request $request): RedirectResponse
+    {
+        $pathInfo = $request->getPathInfo();
+        $requestUri = $request->getRequestUri();
+
+        $url = str_replace($pathInfo, rtrim($pathInfo, ' /'), $requestUri);
+
+        // 308 (Permanent Redirect) is similar to 301 (Moved Permanently) except
+        // that it does not allow changing the request method (e.g. from POST to GET)
+        return $this->redirect($url, 308);
     }
 
     /**

--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -12,6 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -22,8 +23,8 @@ use Symfony\Component\HttpFoundation\Request;
 class ApiController extends Controller
 {
     /**
-     * @Route("/adventures/", name="api_adventures")
-     * @Method({"GET"})
+     * @Route("/adventures", name="api_adventures")
+     * @Method("GET")
      *
      * @return JsonResponse
      */
@@ -38,6 +39,27 @@ class ApiController extends Controller
                 return $serializer->serializeAdventureDocument($adventure);
             }, $adventures),
         ]);
+    }
+
+    /**
+     * Redirect from route with trailing slash to route without trailing slash.
+     * Based on https://symfony.com/doc/3.4/routing/redirect_trailing_slash.html
+     *
+     * TODO: Remove in Symfony 4.x (https://symfony.com/doc/4.4/routing.html#redirecting-urls-with-trailing-slashes)
+     *
+     * @Route("/adventures/")
+     * @Method("GET")
+     */
+    public function redirectFromURLWithTrailingSlashAction(Request $request): RedirectResponse
+    {
+        $pathInfo = $request->getPathInfo();
+        $requestUri = $request->getRequestUri();
+
+        $url = str_replace($pathInfo, rtrim($pathInfo, ' /'), $requestUri);
+
+        // 308 (Permanent Redirect) is similar to 301 (Moved Permanently) except
+        // that it does not allow changing the request method (e.g. from POST to GET)
+        return $this->redirect($url, 308);
     }
 
     /**

--- a/tests/AppBundle/Controller/AdventureControllerTest.php
+++ b/tests/AppBundle/Controller/AdventureControllerTest.php
@@ -15,7 +15,7 @@ class AdventureControllerTest extends WebTestCase
         $this->loadFixtures([AdventureData::class]);
 
         $session = $this->makeSession();
-        $session->visit('/adventures/?filters=not-an-array');
+        $session->visit('/adventures?filters=not-an-array');
         $this->assertTrue($session->getPage()->hasContent('A community for lazy dungeon masters'));
     }
 
@@ -28,12 +28,12 @@ class AdventureControllerTest extends WebTestCase
         $session = $this->makeSession(true);
 
         // Make sure adventure is part of the index
-        $session->visit('/adventures/');
+        $session->visit('/adventures');
         $this->assertTrue($session->getPage()->hasContent($adventure->getTitle()));
 
         $session->visit("/adventures/{$adventure->getSlug()}");
         $session->getPage()->findButton('Delete')->click();
-        $this->assertPath($session, '/adventures/');
+        $this->assertPath($session, '/adventures');
 
         // Verify index still working
         $this->assertWorkingIndex($session);
@@ -50,7 +50,7 @@ class AdventureControllerTest extends WebTestCase
         $session = $this->makeSession(false);
 
         // Make sure non authenticated user is redirected to login when clicking new adventure button
-        $session->visit('/adventures/');
+        $session->visit('/adventures');
         $session->getPage()->findLink('Add a new adventure')->click();
 
         $this->assertPath($session, self::LOGIN_URL);

--- a/tests/AppBundle/Controller/AdventureControllerTest.php
+++ b/tests/AppBundle/Controller/AdventureControllerTest.php
@@ -10,13 +10,11 @@ class AdventureControllerTest extends WebTestCase
 {
     const LOGIN_URL = '/login';
 
-    public function testInvalidFilters()
+    public function testRedirect()
     {
-        $this->loadFixtures([AdventureData::class]);
-
         $session = $this->makeSession();
-        $session->visit('/adventures?filters=not-an-array');
-        $this->assertTrue($session->getPage()->hasContent('A community for lazy dungeon masters'));
+        $session->visit('/adventures/?foo=bar');
+        $this->assertPath($session, '/adventures?foo=bar');
     }
 
     public function testDelete()

--- a/tests/AppBundle/Controller/ApiControllerTest.php
+++ b/tests/AppBundle/Controller/ApiControllerTest.php
@@ -25,6 +25,13 @@ class ApiControllerTest extends WebTestCase
         }
     }
 
+    public function testRedirect()
+    {
+        $session = $this->makeSession();
+        $session->visit('/api/adventures/?foo=bar');
+        $this->assertPath($session, '/api/adventures?foo=bar');
+    }
+
     public function testShowAction()
     {
         $referenceRepository = $this->loadFixtures([AdventureData::class])->getReferenceRepository();

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -14,6 +14,6 @@ class DefaultControllerTest extends WebTestCase
 
         $session->visit('/');
 
-        $this->assertPath($session, '/adventures/');
+        $this->assertPath($session, '/adventures');
     }
 }

--- a/tests/AppBundle/Controller/SecurityControllerTest.php
+++ b/tests/AppBundle/Controller/SecurityControllerTest.php
@@ -27,7 +27,7 @@ class SecurityControllerTest extends WebTestCase
         $session = $this->makeSession();
         $this->submitUsernameAndPassword($session, 'User #1', 'user1');
 
-        $this->assertPath($session, '/adventures/');
+        $this->assertPath($session, '/adventures');
     }
 
     public function testRedirectIfAlreadyLoggedIn()


### PR DESCRIPTION
There is no need for the trailing slash and it looks ugly, especially when combined with the new URL-based search filters. This PR removes the trailing slash but adds a fallback layer since most links out in the wild include a trailing slash. I also removed the no longer needed "POST" method, since parameters are now always part of the URL.

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/355"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/30ffa423e1eaeaea377db5074bf680be58cbcf75.svg" /></a>

