### PR TITLE
Update charset of existing tables to utf8mb4

### DIFF
--- a/app/DoctrineMigrations/Version20200607073617.php
+++ b/app/DoctrineMigrations/Version20200607073617.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200607073617 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE review RENAME INDEX idx_d889262255cf40f9 TO IDX_794381C655CF40F9');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE review RENAME INDEX idx_794381c655cf40f9 TO IDX_D889262255CF40F9');
+    }
+}

--- a/app/DoctrineMigrations/Version20200607073734.php
+++ b/app/DoctrineMigrations/Version20200607073734.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Error;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200607073734 extends AbstractMigration
+{
+    private $TABLES = ['adventure', 'ext_log_entries', 'ext_translations', 'migration_versions', 'user'];
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        foreach ($this->TABLES as $table) {
+            $this->addSql('ALTER TABLE '.$table.' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        foreach ($this->TABLES as $table) {
+            $this->addSql('ALTER TABLE '.$table.' CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
+        }
+    }
+}


### PR DESCRIPTION
The first migration is auto-generated. I'm not sure why it insists on updating the name of the index, but I also checked on the prod server and it wants to generate the same migration.

The second migration closes #39 by changing the charset and collation of all tables that still use `utf8` to `utf8mb4`.

You can verify that this worked by
- trying to add an adventure with an emoji in its title (fails without this migration)
- executing `SHOW TABLE STATUS` and `SHOW FULL COLUMNS FROM TABLE_NAME_HERE;` in the mysql console (`mysql -uroot -proot adl`) before and after running the migration.

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/356"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/4603fa0cf3414ec29a2ebf0d45d1e36fc0c6b90b.svg" /></a>

