### PR TITLE
Add option to filter by "unknown", add counts to boolean fields

### DIFF
--- a/app/Resources/views/adventures/search_results.html.twig
+++ b/app/Resources/views/adventures/search_results.html.twig
@@ -7,18 +7,26 @@
                 {% endif %}
                 <div class="title">{{ adventure.title }}</div>
                 <div class="tags-container">
-                    <div class="tag tag-edition">{{ adventure.edition }}</div>
+                    <div class="tag tag-edition">
+                        {{ adventure.edition ?: 'Unknown Edition' }}
+                    </div>
                     {% set level = format_level(adventure) %}
                     {% if level %}
                         <div class="tag tag-level">{{ level }}</div>
                     {% endif %}
-                    <div class="tag tag-length">{{ adventure.numPages }} pages</div>
+                    <div class="tag tag-length">{{ adventure.numPages ?: '?' }} pages</div>
                     <div class="tag" title="Reviews">
                         <i class="fa fa-thumbs-up"></i> {{ adventure.numPositiveReviews }}&nbsp;
                         <i class="fa fa-thumbs-down"></i> {{ adventure.numNegativeReviews }}
                     </div>
                 </div>
-                <p class="description">{{ adventure.description }}</p>
+                <p class="description">
+                    {% if adventure.description %}
+                        {{ adventure.description }}
+                    {% else %}
+                        <em>No description available.</em>
+                    {% endif %}
+                </p>
             </div>
         </a>
     {% endfor %}

--- a/app/Resources/views/api/docs.html.twig
+++ b/app/Resources/views/api/docs.html.twig
@@ -25,18 +25,32 @@
         <li>
           <span class="badge badge-primary">string</span>
           You can specify multiple values by joining them with a <code>~</code>.
-          If a value itself contains a <code>~</code>, escape it using another <code>~</code>.
+          If a value itself contains a <code>~</code>, escape it by <code>~~</code>.
+          You also have to escape <code>?</code> by <code>??</code>.
           <br />
           Example: Adventures with Gnolls or Pegasuses: <a href="{{ path('api_adventures', { commonMonsters: 'Gnoll~Pegasus' })}}">
             {{ url('api_adventures', { commonMonsters: 'Gnoll~Pegasus' })}}
+          </a>
+          <br />
+          For some adventures, the value might be unknown. To also include these when using the filter, append <code>~?</code>
+          to the parameter: <a href="{{ path('api_adventures', { commonMonsters: 'Gnoll~Pegasus~?' })}}">
+            {# We add the query string manually so that it is not URL encoded and easier to read #}
+            {{ url('api_adventures')}}?commonMonsters=Gnoll~Pegasus~?
           </a>
         </li>
         <li>
           <span class="badge badge-primary">integer</span>
           You can specify the minimum (inclusive) and maximum (inclusive).
           <br />
-          Example: Adventures written between 1990 and 2005: <a href="{{ path('api_adventures', { ('year-min'): 1990, ('year-max'): 2005 })}}">
-            {{ url('api_adventures', { ('year-min'): 1990, ('year-max'): 2005 })}}
+          Example: Adventures written between 1990 and 2005: <a href="{{ path('api_adventures', { year: '≥1990~≤2005' })}}">
+            {# We add the query string manually so that it is not URL encoded and easier to read #}
+            {{ url('api_adventures') }}?year=≥1990~≤2005
+          </a>
+          <br />
+          For some adventures, the value might be unknown. To also include these when using the filter, append <code>~?</code>
+          to the parameter: <a href="{{ path('api_adventures', { year: '≥1990~≤2005~?' })}}">
+            {# We add the query string manually so that it is not URL encoded and easier to read #}
+            {{ url('api_adventures')}}?year=≥1990~≤2005~?
           </a>
         </li>
         <li>

--- a/app/Resources/webpack/js/adventures_filter/Filters.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Filters.jsx
@@ -33,9 +33,10 @@ export const Filters = React.memo(function Filters({
             <FieldFilter
               key={field.name}
               field={field}
+              initialFilter={initialFilterValues[field.name]}
               filter={filterValues[field.name]}
               setFilter={setFilter}
-              fieldValues={fieldStats[`vals_${field.name}`]}
+              fieldValues={fieldStats[field.name]}
               visibility={
                 i < showMoreAfter ||
                 showMoreFilters ||
@@ -62,6 +63,7 @@ export const Filters = React.memo(function Filters({
 const FieldFilter = React.memo(function FieldFilter({
   field,
   visibility,
+  initialFilter,
   filter,
   setFilter,
   fieldValues,
@@ -111,8 +113,10 @@ const FieldFilter = React.memo(function FieldFilter({
         {field.type === "boolean" && (
           <BooleanOptions
             field={field}
+            initialFilter={initialFilter}
             filter={filter}
             setFilter={setFilter}
+            fieldValues={fieldValues}
             onIsDirty={setIsDirty}
           />
         )}
@@ -267,7 +271,22 @@ function StringCheckbox({ field, value, checked, count, hidden, onChange }) {
   );
 }
 
-function BooleanOptions({ field, filter, setFilter, onIsDirty }) {
+function BooleanOptions({
+  field,
+  fieldValues,
+  initialFilter,
+  filter,
+  setFilter,
+  onIsDirty,
+}) {
+  // Only display number of adventures that selected "no"/"yes" if the user
+  // doesn't filter by this field. If the user filters by all adventures that
+  // selected "no", the "yes" bucket is always empty and displaying a 0 for
+  // "yes" could be confusing.
+  const noCount = initialFilter.v === "" ? fieldValues.countNo : undefined;
+  const yesCount = initialFilter.v === "" ? fieldValues.countYes : undefined;
+  const allCount = initialFilter.v === "" ? fieldValues.countAll : undefined;
+
   return (
     <div className="option">
       <div className="form-check form-check-inline">
@@ -286,7 +305,10 @@ function BooleanOptions({ field, filter, setFilter, onIsDirty }) {
           className="form-check-label"
           htmlFor={`sidebar-filter-${field.name}-all`}
         >
-          All
+          All{" "}
+          {allCount !== undefined && (
+            <span className="badge-pill badge badge-info">{allCount}</span>
+          )}
         </label>
       </div>
       <div className="form-check form-check-inline">
@@ -305,7 +327,10 @@ function BooleanOptions({ field, filter, setFilter, onIsDirty }) {
           className="form-check-label"
           htmlFor={`sidebar-filter-${field.name}-yes`}
         >
-          Yes
+          Yes{" "}
+          {yesCount !== undefined && (
+            <span className="badge-pill badge badge-info">{yesCount}</span>
+          )}
         </label>
       </div>
       <div className="form-check form-check-inline">
@@ -324,7 +349,10 @@ function BooleanOptions({ field, filter, setFilter, onIsDirty }) {
           className="form-check-label"
           htmlFor={`sidebar-filter-${field.name}-no`}
         >
-          No
+          No{" "}
+          {noCount !== undefined && (
+            <span className="badge-pill badge badge-info">{noCount}</span>
+          )}
         </label>
       </div>
     </div>

--- a/app/Resources/webpack/js/adventures_filter/Filters.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Filters.jsx
@@ -3,6 +3,7 @@ import { isFilterValueEmpty } from "./field-util";
 
 export const Filters = React.memo(function Filters({
   fields,
+  initialFilterValues,
   filterValues,
   setFilterValues,
   fieldStats,
@@ -38,7 +39,7 @@ export const Filters = React.memo(function Filters({
               visibility={
                 i < showMoreAfter ||
                 showMoreFilters ||
-                !isFilterValueEmpty(field, filterValues[field.name].v)
+                !isFilterValueEmpty(field, initialFilterValues[field.name].v)
                   ? "YES"
                   : "SHOW_MORE"
               }

--- a/app/Resources/webpack/js/adventures_filter/Filters.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Filters.jsx
@@ -154,83 +154,99 @@ function BooleanOptions({
   setFilter,
   onIsDirty,
 }) {
-  // Only display number of adventures that selected "no"/"yes" if the user
-  // doesn't filter by this field. If the user filters by all adventures that
+  // Only display number of adventures that selected "no"/"yes" if the option
+  // matches the user's selection. If the user filters by all adventures that
   // selected "no", the "yes" bucket is always empty and displaying a 0 for
   // "yes" could be confusing.
-  const noCount = initialFilter.v === "" ? fieldValues.countNo : undefined;
-  const yesCount = initialFilter.v === "" ? fieldValues.countYes : undefined;
+  const noCount =
+    initialFilter.v === "" || initialFilter.v === "0"
+      ? fieldValues.countNo
+      : undefined;
+  const yesCount =
+    initialFilter.v === "" || initialFilter.v === "1"
+      ? fieldValues.countYes
+      : undefined;
   const allCount = initialFilter.v === "" ? fieldValues.countAll : undefined;
 
   return (
-    <div className="option option-boolean">
-      <div className="form-check form-check-inline">
-        <input
-          className="form-check-input"
-          type="radio"
-          value=""
-          id={`sidebar-filter-${field.name}-all`}
-          checked={filter.v === ""}
-          onChange={() => {
-            setFilter({ ...filter, v: "" });
-            onIsDirty(true);
-          }}
-        />
-        <label
-          className="form-check-label"
-          htmlFor={`sidebar-filter-${field.name}-all`}
-        >
-          All{" "}
-          {allCount !== undefined && (
-            <span className="badge-pill badge badge-info">{allCount}</span>
-          )}
-        </label>
+    <>
+      <div className="option option-boolean">
+        <div className="form-check form-check-inline">
+          <input
+            className="form-check-input"
+            type="radio"
+            value=""
+            id={`sidebar-filter-${field.name}-all`}
+            checked={filter.v === ""}
+            onChange={() => {
+              setFilter({ ...filter, v: "" });
+              onIsDirty(true);
+            }}
+          />
+          <label
+            className="form-check-label"
+            htmlFor={`sidebar-filter-${field.name}-all`}
+          >
+            All{" "}
+            {allCount !== undefined && (
+              <span className="badge-pill badge badge-info">{allCount}</span>
+            )}
+          </label>
+        </div>
+        <div className="form-check form-check-inline">
+          <input
+            className="form-check-input"
+            type="radio"
+            value="1"
+            id={`sidebar-filter-${field.name}-yes`}
+            checked={filter.v === "1"}
+            onChange={() => {
+              setFilter({ ...filter, v: "1" });
+              onIsDirty(true);
+            }}
+          />
+          <label
+            className="form-check-label"
+            htmlFor={`sidebar-filter-${field.name}-yes`}
+          >
+            Yes{" "}
+            {yesCount !== undefined && (
+              <span className="badge-pill badge badge-info">{yesCount}</span>
+            )}
+          </label>
+        </div>
+        <div className="form-check form-check-inline">
+          <input
+            className="form-check-input"
+            type="radio"
+            value="0"
+            id={`sidebar-filter-${field.name}-no`}
+            checked={filter.v === "0"}
+            onChange={() => {
+              setFilter({ ...filter, v: "0" });
+              onIsDirty(true);
+            }}
+          />
+          <label
+            className="form-check-label"
+            htmlFor={`sidebar-filter-${field.name}-no`}
+          >
+            No{" "}
+            {noCount !== undefined && (
+              <span className="badge-pill badge badge-info">{noCount}</span>
+            )}
+          </label>
+        </div>
       </div>
-      <div className="form-check form-check-inline">
-        <input
-          className="form-check-input"
-          type="radio"
-          value="1"
-          id={`sidebar-filter-${field.name}-yes`}
-          checked={filter.v === "1"}
-          onChange={() => {
-            setFilter({ ...filter, v: "1" });
-            onIsDirty(true);
-          }}
-        />
-        <label
-          className="form-check-label"
-          htmlFor={`sidebar-filter-${field.name}-yes`}
-        >
-          Yes{" "}
-          {yesCount !== undefined && (
-            <span className="badge-pill badge badge-info">{yesCount}</span>
-          )}
-        </label>
-      </div>
-      <div className="form-check form-check-inline">
-        <input
-          className="form-check-input"
-          type="radio"
-          value="0"
-          id={`sidebar-filter-${field.name}-no`}
-          checked={filter.v === "0"}
-          onChange={() => {
-            setFilter({ ...filter, v: "0" });
-            onIsDirty(true);
-          }}
-        />
-        <label
-          className="form-check-label"
-          htmlFor={`sidebar-filter-${field.name}-no`}
-        >
-          No{" "}
-          {noCount !== undefined && (
-            <span className="badge-pill badge badge-info">{noCount}</span>
-          )}
-        </label>
-      </div>
-    </div>
+      <IncludeUnknownOption
+        field={field}
+        fieldValues={fieldValues}
+        initialFilter={initialFilter}
+        filter={filter}
+        setFilter={setFilter}
+        onIsDirty={onIsDirty}
+      />
+    </>
   );
 }
 
@@ -279,33 +295,54 @@ function IntegerOptions({
           onKeyPress={(key) => key.which === 13 && onSubmit()}
         />
       </div>
-      {!isFilterValueEmpty(field, filter) && (
-        <label
-          className="option"
-          title="Include adventures where this field is unknown, regardless of the filter set above."
-        >
-          <input
-            type="checkbox"
-            onChange={(e) => {
-              const value = e.target.checked;
-              setFilter((filter) => ({
-                ...filter,
-                includeUnknown: value,
-              }));
-              onIsDirty(true);
-            }}
-            checked={filter.includeUnknown}
-          />
-          Include when unknown
-          <div className="spacer" />
-          {(initialFilter.includeUnknown ||
-            (initialFilter.v.min === "" && initialFilter.v.max === "")) && (
-            <span className="badge-pill badge badge-info">
-              {fieldValues.countUnknown}
-            </span>
-          )}
-        </label>
-      )}
+      <IncludeUnknownOption
+        field={field}
+        fieldValues={fieldValues}
+        initialFilter={initialFilter}
+        filter={filter}
+        setFilter={setFilter}
+        onIsDirty={onIsDirty}
+      />
     </>
+  );
+}
+
+function IncludeUnknownOption({
+  field,
+  fieldValues,
+  initialFilter,
+  filter,
+  setFilter,
+  onIsDirty,
+}) {
+  if (isFilterValueEmpty(field, filter)) {
+    return null;
+  }
+  return (
+    <label
+      className="option"
+      title="Include adventures where this field is unknown, regardless of the filter set above."
+    >
+      <input
+        type="checkbox"
+        onChange={(e) => {
+          const value = e.target.checked;
+          setFilter((filter) => ({
+            ...filter,
+            includeUnknown: value,
+          }));
+          onIsDirty(true);
+        }}
+        checked={filter.includeUnknown}
+      />
+      Include when unknown
+      <div className="spacer" />
+      {(initialFilter.includeUnknown ||
+        isFilterValueEmpty(field, initialFilter)) && (
+        <span className="badge-pill badge badge-info">
+          {fieldValues.countUnknown}
+        </span>
+      )}
+    </label>
   );
 }

--- a/app/Resources/webpack/js/adventures_filter/Root.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Root.jsx
@@ -48,23 +48,27 @@ export function Root({
             if (filter.v.max !== "") {
               args.push(`≤${filter.v.max}`);
             }
-            if (filter.includeUnknown === true) {
-              args.push("?");
+            if (args.length > 0 && filter.includeUnknown === true) {
+              args.push("unknown");
             }
             addParam(field.name, args.join("~"));
             break;
           case "string": {
-            const args = filter.v.map((value) =>
-              value.replace(/~/g, "~~").replace(/\?/g, "??")
-            );
-            if (filter.includeUnknown) {
-              args.push("?");
+            let value = filter.v
+              .map((value) => value.replace(/~/g, "~~"))
+              .join("~");
+            if (value !== "" && filter.includeUnknown) {
+              value += "~unknown~";
             }
-            addParam(field.name, args.join("~"));
+            addParam(field.name, value);
             break;
           }
           case "boolean":
-            addParam(field.name, filter.v);
+            let value = filter.v;
+            if (value !== "" && filter.includeUnknown) {
+              value += "~unknown";
+            }
+            addParam(field.name, value);
             break;
           case "text":
           case "url":

--- a/app/Resources/webpack/js/adventures_filter/Root.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Root.jsx
@@ -41,16 +41,26 @@ export function Root({
         const filter = filterValues[field.name];
         switch (field.type) {
           case "integer":
-            addParam(`${field.name}-min`, filter.v.min);
-            addParam(`${field.name}-max`, filter.v.max);
+            const args = [];
+            if (filter.v.min !== "") {
+              args.push(`≥${filter.v.min}`);
+            }
+            if (filter.v.max !== "") {
+              args.push(`≤${filter.v.max}`);
+            }
+            if (filter.includeUnknown === true) {
+              args.push("?");
+            }
+            addParam(field.name, args.join("~"));
             break;
           case "string": {
-            if (filter.v.length > 0) {
-              addParam(
-                field.name,
-                filter.v.map((value) => value.replace(/~/g, "~~")).join("~")
-              );
+            const args = filter.v.map((value) =>
+              value.replace(/~/g, "~~").replace(/\?/g, "??")
+            );
+            if (filter.includeUnknown) {
+              args.push("?");
             }
+            addParam(field.name, args.join("~"));
             break;
           }
           case "boolean":

--- a/app/Resources/webpack/js/adventures_filter/Root.jsx
+++ b/app/Resources/webpack/js/adventures_filter/Root.jsx
@@ -90,6 +90,7 @@ export function Root({
         </a>
         <Filters
           fields={fields}
+          initialFilterValues={initialFilterValues}
           filterValues={filterValues}
           setFilterValues={setFilterValues}
           fieldStats={fieldStats}

--- a/app/Resources/webpack/js/adventures_filter/SearchTags.jsx
+++ b/app/Resources/webpack/js/adventures_filter/SearchTags.jsx
@@ -19,7 +19,7 @@ export function SearchTags({
 
   const activeFilters = Object.entries(initialFilterValues)
     .map(([fieldName, filter]) => [fieldsByName[fieldName], filter])
-    .filter(([field, filter]) => !isFilterValueEmpty(field, filter.v));
+    .filter(([field, filter]) => !isFilterValueEmpty(field, filter));
 
   const removeAll = () => {
     activeFilters.forEach(([field]) => {
@@ -34,24 +34,43 @@ export function SearchTags({
   return (
     <div id="search-tags">
       {activeFilters.map(([field, filter]) => {
-        return getTagValuesFromFilter(field, filter).map((tag, i) => {
+        const tags = getTagValuesFromFilter(field, filter);
+        const tagElements = tags.map((tag, i) => {
           return (
-            <span
-              key={i}
-              className="badge badge-primary filter-tag"
-              onClick={() => {
-                setFilterValues({
-                  ...initialFilterValues,
-                  [field.name]: tag.without(),
-                });
-                onSubmit();
-              }}
-              title="Clear Filter"
-            >
-              {field.title}: {tag.label}{" "}
+            // wrap into an inline-block so that the operator is always in front of the tag,
+            // even when wrapped accross multiple lines
+            <span key={i} className="d-inline-block">
+              {i > 0 && <span className="tag-operator">{tag.operator}</span>}
+              <span
+                className="badge badge-primary"
+                onClick={() => {
+                  setFilterValues((initialFilterValues) => {
+                    return {
+                      ...initialFilterValues,
+                      [field.name]: tag.without(
+                        initialFilterValues[field.name]
+                      ),
+                    };
+                  });
+                  onSubmit();
+                }}
+                title="Clear Filter"
+              >
+                {field.title}: {tag.label}{" "}
+              </span>
             </span>
           );
         });
+
+        if (tagElements.length > 1) {
+          return (
+            <div className="tag-wrapper" key={field.name}>
+              {tagElements}
+            </div>
+          );
+        }
+
+        return tagElements;
       })}
       {activeFilters.length > 0 && (
         <span

--- a/app/Resources/webpack/js/adventures_filter/StringFilter.jsx
+++ b/app/Resources/webpack/js/adventures_filter/StringFilter.jsx
@@ -1,0 +1,275 @@
+import * as React from "react";
+
+function filterOption(option, searchString) {
+  return option.toLowerCase().includes(searchString.toLowerCase());
+}
+
+export function StringFilter({
+  field,
+  // ElasticSearch statistics based on the search results for `initialFilter`. If a
+  // filter option is not part of `fieldValues.buckets`, none of the search results
+  // (based on `initialFilter`) use this filter option.
+  fieldValues,
+  initialFilter,
+  filter,
+  setFilter,
+  onIsDirty,
+}) {
+  const unknownLabel = field.multiple ? "none" : "unknown";
+
+  // We want to show options in the following order:
+  // 1. All options from `initialFilter`
+  // 2. Unknown/None iff `initialFilter` is empty AND there are adventure
+  //    where the field value is unknown.
+  // 3. All options from `fieldValues.buckets` that are not part of `initialFilter`.
+
+  // 1.
+  // We deliberately use `initialFilter` instead of `filter` here. We want
+  // to display all filters prominently that made up the currently displayed
+  // search results. Using `filter` would cause these to show up just fine
+  // initially, but move them down the list of filter options once the user
+  // deselects them. By using `initialFilter`, the options will only move down
+  // the list once the user "applys" the new filters and the page reloads.
+  //
+  // We also map the initial filters into the same format as fieldValues.buckets
+  // to make the code below more consistent.
+  const initialOptions = initialFilter.v.map((value) => ({
+    key: value,
+    doc_count:
+      // If `value` is not found in `fieldValues.buckets`,
+      // none of the search results use this value => There aren't any
+      // search results and it's okay to display `0` as `count`.
+      fieldValues.buckets.find((bucket) => bucket.key === value)?.doc_count ??
+      0,
+  }));
+
+  // 2.
+  // We only show the Unknown option if any adventures in the currently displayed
+  // search results have a field value of unknown OR the user has specifically
+  // selected the option.
+  const showUnknownOption =
+    (initialOptions.length === 0 && fieldValues.countUnknown > 0) ||
+    initialFilter.includeUnknown;
+
+  // 3.
+  const additionalOptions = fieldValues.buckets.filter(
+    (bucket) => !initialOptions.some((option) => option.key === bucket.key)
+  );
+
+  // Displayed options can be filtered to more easily find particular options. This
+  // corresponds to what the user types into the filter input box.
+  const [filterString, setFilterString] = React.useState("");
+  // selectAllState is the state of the checkbox next to the filter input box.
+  // It can either be selected (`true`), unselected (`false`), or indeterminate (`"indeterminate"`).
+  const [selectAllState, setSelectAllState] = React.useState("indeterminate");
+
+  // Let's re-calculate the available options from the `filterString` now.
+
+  // 1.
+  const filteredInitialOptions =
+    filterString.length === 0
+      ? initialOptions
+      : initialOptions.filter((option) =>
+          filterOption(option.key, filterString)
+        );
+
+  // 2.
+  const filteredShowUnknownOption =
+    showUnknownOption && filterOption(unknownLabel, filterString);
+
+  // 3.
+  const filteredAdditionalOptions =
+    filterString.length === 0
+      ? additionalOptions
+      : additionalOptions.filter((option) =>
+          filterOption(option.key, filterString)
+        );
+
+  // Initially, only the first `showMoreAfter` `filteredAdditionalOptions` are shown (`showAll` = `false`).
+  // We always show all `filteredInitialOptions` though.
+  const showMoreAfter = 5;
+  const [showAll, setShowAll] = React.useState(false);
+
+  // Check if any options are available, ignoring the filter options input box.
+  if (
+    initialOptions.length === 0 &&
+    !showUnknownOption &&
+    additionalOptions.length === 0
+  ) {
+    return (
+      <div className="option">
+        <em>
+          No options available. Remove some search filters to show more options.
+        </em>
+      </div>
+    );
+  }
+
+  const onSelectAllCheckboxChange = ({ target: { checked } }) => {
+    setSelectAllState(checked);
+    setShowAll(true);
+    onIsDirty(true);
+    if (checked) {
+      setFilter((filter) => ({
+        ...filter,
+        // Set includeUnknown only when the option is visible, leave it untouched otherwise.
+        includeUnknown: filteredShowUnknownOption
+          ? true
+          : filter.includeUnknown,
+        // Select all currently selected options and all currently visible options
+        // => filter.v UNION filteredInitialOptions UNION filteredAdditionalOptions
+        v: [
+          ...filter.v,
+          ...filteredInitialOptions
+            .map((option) => option.key)
+            .filter((value) => !filter.v.includes(value)),
+          ...filteredAdditionalOptions
+            .map((option) => option.key)
+            .filter((value) => !filter.v.includes(value)),
+        ],
+      }));
+    } else {
+      setFilter((filter) => ({
+        ...filter,
+        // Set includeUnknown only when the option is visible, leave it untouched otherwise.
+        includeUnknown: filteredShowUnknownOption
+          ? false
+          : filter.includeUnknown,
+        // Remove all currently visible options from selected options
+        // => filter.v MINUS (filteredInitialOptions UNION filteredAdditionalOptions)
+        v: filter.v.filter(
+          (each) =>
+            !(
+              filteredInitialOptions.some((option) => option.key === each) ||
+              filteredAdditionalOptions.some((option) => option.key === each)
+            )
+        ),
+      }));
+    }
+  };
+
+  return (
+    <>
+      <div className="string-options">
+        {/* Option filter bar */}
+        <div className="option">
+          <input
+            type="checkbox"
+            title="select all"
+            checked={selectAllState === true}
+            ref={(input) => {
+              if (input) {
+                input.indeterminate = selectAllState === "indeterminate";
+              }
+            }}
+            onChange={onSelectAllCheckboxChange}
+          />
+          <input
+            className="filter-searchbar"
+            type="text"
+            placeholder="Find Option"
+            onChange={(e) => {
+              setFilterString(e.target.value);
+              setSelectAllState("indeterminate");
+              setShowAll(true);
+            }}
+            value={filterString}
+            title="Find Option"
+          />
+        </div>
+        {/* 1. Initial options */}
+        {filteredInitialOptions.map((option) => (
+          <StringCheckbox
+            key={option.key}
+            label={option.key}
+            checked={filter.v.includes(option.key)}
+            count={option.doc_count}
+            onChange={(selected) => {
+              setFilter((filter) => ({
+                ...filter,
+                v: selected
+                  ? [...filter.v, option.key]
+                  : filter.v.filter((each) => each !== option.key),
+              }));
+              setSelectAllState("indeterminate");
+              onIsDirty(true);
+            }}
+          />
+        ))}
+        {/* 2. Unknown option */}
+        {filteredShowUnknownOption && (
+          <StringCheckbox
+            label={<em>{unknownLabel}</em>}
+            checked={filter.includeUnknown}
+            count={fieldValues.countUnknown}
+            onChange={(selected) => {
+              setFilter((filter) => ({
+                ...filter,
+                includeUnknown: selected,
+              }));
+              setSelectAllState("indeterminate");
+              onIsDirty(true);
+            }}
+          />
+        )}
+        {/* 3. Additional options */}
+        {filteredAdditionalOptions
+          .slice(0, showAll ? undefined : showMoreAfter)
+          .map((option) => (
+            <StringCheckbox
+              key={option.key}
+              label={option.key}
+              checked={filter.v.includes(option.key)}
+              count={option.doc_count}
+              onChange={(selected) => {
+                setFilter((filter) => ({
+                  ...filter,
+                  v: selected
+                    ? [...filter.v, option.key]
+                    : filter.v.filter((each) => each !== option.key),
+                }));
+                setSelectAllState("indeterminate");
+                onIsDirty(true);
+              }}
+            />
+          ))}
+      </div>
+      {filteredAdditionalOptions.length > showMoreAfter && (
+        <>
+          {!showAll ? (
+            <div
+              className="option show-more"
+              onClick={() => setShowAll(true)}
+              title="show more"
+            >
+              <i className="fa fa-arrow-down"></i>
+            </div>
+          ) : (
+            <div
+              className="option show-less"
+              onClick={() => setShowAll(false)}
+              title="show less"
+            >
+              <i className="fa fa-arrow-up"></i>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
+function StringCheckbox({ label, checked, count, onChange }) {
+  return (
+    <label className="option">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+      <div className="spacer" />
+      <span className="badge-pill badge badge-info">{count}</span>
+    </label>
+  );
+}

--- a/app/Resources/webpack/js/adventures_filter/field-util.js
+++ b/app/Resources/webpack/js/adventures_filter/field-util.js
@@ -18,10 +18,12 @@ export function getEmptyFilter(field) {
     case "string":
       return {
         v: [],
+        includeUnknown: false,
       };
     case "boolean":
       return {
         v: "",
+        includeUnknown: false,
       };
     case "integer":
       return {
@@ -29,6 +31,7 @@ export function getEmptyFilter(field) {
           min: "",
           max: "",
         },
+        includeUnknown: false,
       };
     case "text":
     case "url":
@@ -60,11 +63,11 @@ export function getTagValuesFromFilter(field, filter) {
       }
       return tags;
     }
-    case "boolean":
+    case "boolean": {
       if (filter.v === "") {
         return [];
       }
-      return [
+      const tags = [
         {
           label: filter.v === "1" ? "yes" : "no",
           operator: "OR",
@@ -74,6 +77,18 @@ export function getTagValuesFromFilter(field, filter) {
           }),
         },
       ];
+      if (filter.includeUnknown === true) {
+        tags.push({
+          label: "unknown",
+          operator: "OR",
+          without: (filter) => ({
+            ...filter,
+            includeUnknown: false,
+          }),
+        });
+      }
+      return tags;
+    }
     case "integer":
       const tags = [];
       if (filter.v.min !== "") {
@@ -104,7 +119,7 @@ export function getTagValuesFromFilter(field, filter) {
           }),
         });
       }
-      if (filter.includeUnknown === true) {
+      if (tags.length > 0 && filter.includeUnknown === true) {
         tags.push({
           label: "unknown",
           operator: "OR",

--- a/app/Resources/webpack/sass/_adventures.scss
+++ b/app/Resources/webpack/sass/_adventures.scss
@@ -4,6 +4,8 @@ $thumbnail-offset: 2rem;
 $thumbnail-width: 85px;
 $thumbnail-height: 100px;
 
+$tag-margin: 4px;
+
 #search-title {
   display: flex;
   justify-content: space-between;
@@ -14,8 +16,22 @@ $thumbnail-height: 100px;
 #search-tags {
   margin: $element-margin-bottom 0;
 
-  > span.badge {
-    margin-right: 4px;
+  .badge, .tag-operator, .tag-wrapper {
+    margin-right: $tag-margin;
+    margin-bottom: $tag-margin;
+  }
+
+  .tag-wrapper {
+    display: inline-block;
+    border: 1px solid $adl-grey-light;
+    border-radius: 2px;
+    padding-top: $tag-margin;
+    padding-bottom: 0;
+    padding-right: 0;
+    padding-left: $tag-margin;
+  }
+
+  .badge {
     &::after {
       content: '\f00d';
       font: 1rem 'FontAwesome';
@@ -33,7 +49,7 @@ $thumbnail-height: 100px;
 
         &:hover {
             background-color: darken($adl-grey-light, 7.5%);
-        } 
+        }
     }
   }
 }

--- a/app/Resources/webpack/sass/_filter.scss
+++ b/app/Resources/webpack/sass/_filter.scss
@@ -9,7 +9,7 @@
     .options-list { display: initial; }
     .option {
       display: flex;
-      &.range-option {
+      &.option-integer {
         @include media-breakpoint-down(md) {
           flex-direction: column;
         }
@@ -81,7 +81,9 @@
       cursor: pointer;
     }
 
-    &.range-option {
+    &.option-integer {
+      display: flex;
+
       input {
         border-radius: 0;
         @include media-breakpoint-up(lg) {
@@ -96,6 +98,15 @@
           margin-right: 3px;
         }
       }
+
+      @include media-breakpoint-down(md) {
+        flex-direction: column;
+      }
+    }
+
+    &.option-integer:hover, &.option-boolean:hover {
+      background-color: $adl-grey-darkest;
+      cursor: default;
     }
   }
   &-searchbar{
@@ -113,20 +124,6 @@
     }
     &:hover {
       background-color: $adl-grey-dark;
-      cursor: default;
-    }
-  }
-
-  .option {
-    display: flex;
-    &.range-option {
-      @include media-breakpoint-down(md) {
-        flex-direction: column;
-      }
-    }
-
-    &:not(.apply):hover {
-      background-color: $adl-grey-darkest;
       cursor: default;
     }
   }

--- a/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
+++ b/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
@@ -21,6 +21,7 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Faker;
+use Faker\Generator;
 
 class RandomAdventureData implements FixtureInterface, ContainerAwareInterface, DependentFixtureInterface
 {
@@ -73,14 +74,14 @@ class RandomAdventureData implements FixtureInterface, ContainerAwareInterface, 
                 ->setTitle($faker->unique->catchPhrase)
                 ->setDescription($faker->realText(2000))
                 ->setNumPages($faker->numberBetween(1, 200))
-                ->setFoundIn($faker->catchPhrase)
-                ->setPartOf($faker->boolean() ? $faker->catchPhrase : null)
+                ->setFoundIn($faker->boolean(20) ? $faker->catchPhrase : null)
+                ->setPartOf($faker->boolean(20) ? $faker->catchPhrase : null)
                 ->setLink($faker->url)
                 ->setThumbnailUrl($faker->picsumUrl(260, 300))
-                ->setSoloable($faker->boolean())
-                ->setPregeneratedCharacters($faker->boolean())
-                ->setTacticalMaps($faker->boolean())
-                ->setHandouts($faker->boolean())
+                ->setSoloable($this->boolOrNull($faker))
+                ->setPregeneratedCharacters($this->boolOrNull($faker))
+                ->setTacticalMaps($this->boolOrNull($faker))
+                ->setHandouts($this->boolOrNull($faker))
                 ->setAuthors(new ArrayCollection($faker->randomElements($authors, $faker->numberBetween(1, 3))))
                 ->setEdition($faker->randomElement($editions))
                 ->setEnvironments(new ArrayCollection($faker->randomElements($environments, $faker->numberBetween(1, 2))))
@@ -145,5 +146,14 @@ class RandomAdventureData implements FixtureInterface, ContainerAwareInterface, 
             $em->persist($adventure);
         }
         $em->flush();
+    }
+
+    private function boolOrNull(Generator $faker)
+    {
+        switch ($faker->numberBetween(-1, 1)) {
+            case 1: return true;
+            case 0: return null;
+            case -1: return false;
+        }
     }
 }

--- a/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
+++ b/src/AppBundle/DataFixtures/ORM/RandomAdventureData.php
@@ -72,23 +72,23 @@ class RandomAdventureData implements FixtureInterface, ContainerAwareInterface, 
             $adventure = new Adventure();
             $adventure
                 ->setTitle($faker->unique->catchPhrase)
-                ->setDescription($faker->realText(2000))
-                ->setNumPages($faker->numberBetween(1, 200))
+                ->setDescription($faker->boolean(95) ? $faker->realText(2000) : null)
+                ->setNumPages($faker->boolean(80) ? $faker->numberBetween(1, 200) : null)
                 ->setFoundIn($faker->boolean(20) ? $faker->catchPhrase : null)
                 ->setPartOf($faker->boolean(20) ? $faker->catchPhrase : null)
-                ->setLink($faker->url)
-                ->setThumbnailUrl($faker->picsumUrl(260, 300))
+                ->setLink($faker->boolean(70) ? $faker->url : null)
+                ->setThumbnailUrl($faker->boolean(70) ? $faker->picsumUrl(260, 300) : null)
                 ->setSoloable($this->boolOrNull($faker))
                 ->setPregeneratedCharacters($this->boolOrNull($faker))
                 ->setTacticalMaps($this->boolOrNull($faker))
                 ->setHandouts($this->boolOrNull($faker))
-                ->setAuthors(new ArrayCollection($faker->randomElements($authors, $faker->numberBetween(1, 3))))
-                ->setEdition($faker->randomElement($editions))
-                ->setEnvironments(new ArrayCollection($faker->randomElements($environments, $faker->numberBetween(1, 2))))
+                ->setAuthors(new ArrayCollection($faker->randomElements($authors, $faker->numberBetween(0, 3))))
+                ->setEdition($faker->boolean(90) ? $faker->randomElement($editions) : null)
+                ->setEnvironments(new ArrayCollection($faker->randomElements($environments, $faker->numberBetween(0, 2))))
                 ->setItems(new ArrayCollection($faker->randomElements($items, $faker->numberBetween(0, 5))))
-                ->setPublisher($faker->randomElement($publishers))
-                ->setYear($faker->numberBetween(1980, 2020))
-                ->setSetting($faker->randomElement($settings))
+                ->setPublisher($faker->boolean(80) ? $faker->randomElement($publishers) : null)
+                ->setYear($faker->boolean(90) ? $faker->numberBetween(1980, 2020) : null)
+                ->setSetting($faker->boolean(80) ? $faker->randomElement($settings) : null)
                 ->setMonsters(new ArrayCollection($faker->randomElements($monsters, $faker->numberBetween(0, 20))));
 
             if ($faker->boolean(20)) {
@@ -130,7 +130,9 @@ class RandomAdventureData implements FixtureInterface, ContainerAwareInterface, 
                 }
             }
 
-            if ($faker->boolean()) {
+            if ($faker->boolean(20)) {
+                // Do not set any level parameter
+            } elseif ($faker->boolean()) {
                 $adventure->setStartingLevelRange($faker->randomElement([
                     'low', 'medium', 'high',
                 ]));


### PR DESCRIPTION
This PR allows you to filter by adventures where a field is `null`. For example, you can now choose to include adventure with an unknown number of pages if you filter by number of pages:
![image](https://user-images.githubusercontent.com/2145092/84009577-c33b5480-a973-11ea-8e46-5ba62c4407a3.png)
Additionally, search tags now indicate more clearly whether they are ORed or ANDed.
Boolean fields now also show a blue bubble with the number of adventures that selected "yes" and "no". These numbers are only shown as long as "all" is selected. This is because the number of adventures that have "no" is always 0 when filtering for "yes" and vice versa.

I also changed the URL behavior slightly once again.
It also fixes the following bug:
> To reproduce, select "soloable = yes", then apply.
> Then select "soloable = all" -> the soloable filter disappears before you apply.

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/357"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/d0b78989f0b1a4e555c5a6c62f8e652bf18cce8f.svg" /></a>

