### PR TITLE
Explicitly mark our affiliate links

### DIFF
--- a/app/Resources/views/adventure/_details.html.twig
+++ b/app/Resources/views/adventure/_details.html.twig
@@ -114,7 +114,19 @@
             </div>
             <div class="col-12">
                 <div class="label">Link</div>
-                <a href="{{ adventure.link|add_affiliate_code|e('html_attr') }}">{{ adventure.link|add_affiliate_code }}</a>
+                {% if adventure.link %}
+                    {% set tmp = adventure.link|add_affiliate_code %}
+                    {% set link, affiliateCodeAdded = tmp[0], tmp[1] %}
+                    <a href="{{ link|e('html_attr') }}" rel="nofollow noopener">{{ link }}</a>
+                    {% if affiliateCodeAdded %}
+                        <sup>
+                            <a href="#affiliate-link-info">1</a>
+                        </sup>
+                    {% endif %}
+                {% else %}
+                    {% set affiliateCodeAdded = false %}
+                    Unknown
+                {% endif %}
             </div>
         </div>
 
@@ -188,5 +200,16 @@
                 </ul>
             </div>
         </div>
+        {% if affiliateCodeAdded %}
+            <div class="detail-row">
+                <div class="col">
+                    <p id="affiliate-link-info" class="text-muted">
+                        <sup>1</sup> This is an affiliate link.
+                        We may get a small comission if you buy something using that link.
+                        There are no additional costs for you.
+                    </p>
+                </div>
+            </div>
+        {% endif %}
     </div>
 </div>

--- a/app/Resources/webpack/js/adventure.js
+++ b/app/Resources/webpack/js/adventure.js
@@ -48,6 +48,7 @@ function debounce(func, wait, immediate) {
             const link = $("<a></a>");
             link.text(adventure.title);
             link.attr("target", "_blank");
+            link.attr("rel", "noopener");
             // TODO: We should not hardcode the URL here!
             link.attr("href", "/adventures/" + adventure["slug"]);
             similarAdventuresList.append($("<li></li>").append(link));

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -24,6 +24,11 @@ services:
         tags:
             - { name: monolog.logger, channel: elasticsearch }
 
+    AppBundle\Service\AffiliateLinkHandler:
+        arguments:
+            $affiliateMappings: '%affiliate_mappings%'
+            $cache: '@Symfony\Component\Cache\Simple\Psr6Cache'
+
     AppBundle\Listener\SearchIndexUpdater:
         arguments:
             $environment: "%kernel.environment%"
@@ -49,11 +54,6 @@ services:
     # see https://github.com/symfony/symfony/pull/25710
     Symfony\Component\Cache\Simple\Psr6Cache:
         arguments: ['@cache.app']
-
-    AppBundle\Twig\AppExtension:
-        arguments:
-            $affiliateMappings: '%affiliate_mappings%'
-            $cache: '@Symfony\Component\Cache\Simple\Psr6Cache'
 
     twig.extension.date:
         class: Twig_Extensions_Extension_Date

--- a/src/AppBundle/Form/Type/AdventureType.php
+++ b/src/AppBundle/Form/Type/AdventureType.php
@@ -10,6 +10,7 @@ use AppBundle\Entity\Item;
 use AppBundle\Entity\Monster;
 use AppBundle\Entity\Publisher;
 use AppBundle\Entity\Setting;
+use AppBundle\Service\AffiliateLinkHandler;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -29,6 +30,16 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 class AdventureType extends AbstractType
 {
+    /**
+     * @var string[]
+     */
+    private $affiliateDomains = [];
+
+    public function __construct(AffiliateLinkHandler $affiliateLinkHandler)
+    {
+        $this->affiliateDomains = $affiliateLinkHandler->getDomains();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -177,7 +188,7 @@ class AdventureType extends AbstractType
             ])
             ->add('link', UrlType::class, [
                 'required' => false,
-                'help' => 'Links to legitimate sites where the module can be procured.',
+                'help' => 'Links to legitimate sites where the module can be procured. Using affiliate links is not allowed. Links to the following domains will automatically be transformed into affiliate links: '.implode(', ', $this->affiliateDomains),
             ])
             ->add('thumbnailUrl', UrlType::class, [
                 'required' => false,

--- a/src/AppBundle/Service/AffiliateLinkHandler.php
+++ b/src/AppBundle/Service/AffiliateLinkHandler.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace AppBundle\Service;
+
+use League\Uri\Components\Host;
+use League\Uri\Components\Query;
+use League\Uri\Http;
+use League\Uri\Modifiers\Formatter;
+use League\Uri\PublicSuffix\CurlHttpClient;
+use League\Uri\PublicSuffix\ICANNSectionManager;
+use League\Uri\QueryParser;
+use Psr\SimpleCache\CacheInterface;
+
+class AffiliateLinkHandler
+{
+    /**
+     * @var array
+     */
+    private $affiliateMappings = [];
+
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    public function __construct(array $affiliateMappings, CacheInterface $cache)
+    {
+        $this->affiliateMappings = $affiliateMappings;
+        $this->cache = $cache;
+    }
+
+    public function getDomains()
+    {
+        $domains = [];
+        foreach ($this->affiliateMappings as $affiliateMapping) {
+            foreach ($affiliateMapping['domains'] as $domain) {
+                $domains[] = $domain;
+            }
+        }
+
+        return array_unique($domains);
+    }
+
+    public function addAffiliateCode(?string $url)
+    {
+        if (null === $url || empty($url)) {
+            return [null, false];
+        }
+
+        $uri = Http::createFromString($url);
+
+        $affiliateCodeAdded = false;
+        if (!empty($this->affiliateMappings)) {
+            $rules = (new ICANNSectionManager($this->cache, new CurlHttpClient()))->getRules();
+            $domain = (new Host($uri->getHost(), $rules))->getRegistrableDomain();
+            $queryParser = new QueryParser();
+
+            foreach ($this->affiliateMappings as $affiliateMapping) {
+                foreach ($affiliateMapping['domains'] as $affiliateDomain) {
+                    if ($affiliateDomain === $domain) {
+                        $queryParameters = $queryParser->extract($uri->getQuery());
+                        $queryParameters[$affiliateMapping['param']] = $affiliateMapping['code'];
+
+                        $affiliateCodeAdded = true;
+                        $uri = $uri->withQuery(Query::createFromPairs($queryParameters)->getContent());
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $formatter = new Formatter();
+        $formatter->setEncoding(Formatter::RFC3987_ENCODING);
+
+        return [$formatter($uri), $affiliateCodeAdded];
+    }
+}

--- a/tests/AppBundle/Service/AffiliateLinkHandlerTest.php
+++ b/tests/AppBundle/Service/AffiliateLinkHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\AppBundle\Service;
+
+use AppBundle\Service\AffiliateLinkHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Simple\FilesystemCache;
+
+class AffiliateLinkHandlerTest extends TestCase
+{
+    /**
+     * @var AffiliateLinkHandler
+     */
+    private $affiliateLinkHandler;
+
+    public function setUp(): void
+    {
+        $affiliateMappings = [
+            [
+                'domains' => ['example.com', 'example.org'],
+                'param' => 'aff_id',
+                'code' => 'aff_code',
+            ],
+            [
+                'domains' => ['foo.bar'],
+                'param' => 'aff_id2',
+                'code' => 'aff_code2',
+            ],
+            [
+                // add duplicate domain example.com to verify that testGetDomains calls array_unique
+                'domains' => ['example.com'],
+                'param' => 'foo',
+                'code' => 'bar',
+            ],
+        ];
+        $this->affiliateLinkHandler = new AffiliateLinkHandler($affiliateMappings, new FilesystemCache());
+    }
+
+    public function testGetDomains()
+    {
+        $this->assertEquals(['example.com', 'example.org', 'foo.bar'], $this->affiliateLinkHandler->getDomains());
+    }
+
+    /**
+     * @dataProvider urlDataProvider
+     */
+    public function testAddAffiliateCode(string $inputUrl = null, string $expectedOutputUrl = null, bool $affiliateCodeAdded)
+    {
+        $this->assertEquals(
+            [$expectedOutputUrl, $affiliateCodeAdded],
+            $this->affiliateLinkHandler->addAffiliateCode($inputUrl)
+        );
+    }
+
+    public function urlDataProvider()
+    {
+        $unrelatedUrl = 'https://www.123.co.uk/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000#foo-bar&x=100';
+
+        return [
+            [null, null, false],
+            ['', '', false],
+            [$unrelatedUrl, $unrelatedUrl, false],
+            ['http://example.com/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000#foo-bar&x=100', 'http://example.com/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000&aff_id=aff_code#foo-bar&x=100', true],
+            ['http://example.org/?aff_id=test', 'http://example.org/?aff_id=aff_code', true],
+            ['http://www.foo.bar/?aff_id=test&aff_id2=test2', 'http://www.foo.bar/?aff_id=test&aff_id2=aff_code2', true],
+        ];
+    }
+}

--- a/tests/AppBundle/Twig/AppExtensionTest.php
+++ b/tests/AppBundle/Twig/AppExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Twig;
 
+use AppBundle\Service\AffiliateLinkHandler;
 use AppBundle\Twig\AppExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Simple\FilesystemCache;
@@ -17,19 +18,11 @@ class AppExtensionTest extends TestCase
 
     public function setUp(): void
     {
-        $affiliateMappings = [
-            [
-                'domains' => ['example.com', 'example.org'],
-                'param' => 'aff_id',
-                'code' => 'aff_code',
-            ],
-            [
-                'domains' => ['foo.bar'],
-                'param' => 'aff_id2',
-                'code' => 'aff_code2',
-            ],
-        ];
-        $this->extension = new AppExtension($affiliateMappings, new FilesystemCache());
+        $this->extension = new AppExtension(new AffiliateLinkHandler([[
+            'domains' => ['example.com'],
+            'param' => 'aff_id',
+            'code' => 'aff_code',
+        ]], new FilesystemCache()));
     }
 
     /**
@@ -40,26 +33,12 @@ class AppExtensionTest extends TestCase
         $this->assertSame($expectedResult, $this->extension->bool2str($boolean));
     }
 
-    /**
-     * @dataProvider urlDataProvider
-     */
-    public function testAddAffiliateCode(string $inputUrl = null, string $expectedOutputUrl = null)
+    public function testAddAffiliateCode()
     {
-        $this->assertEquals($expectedOutputUrl, $this->extension->addAffiliateCode($inputUrl));
-    }
-
-    public function urlDataProvider()
-    {
-        $unrelatedUrl = 'https://www.123.co.uk/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000#foo-bar&x=100';
-
-        return [
-            [null, null],
-            ['', ''],
-            [$unrelatedUrl, $unrelatedUrl],
-            ['http://example.com/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000#foo-bar&x=100', 'http://example.com/foo/bar/../baz/test 123?a=abc&b= aaa&id=1000&aff_id=aff_code#foo-bar&x=100'],
-            ['http://example.org/?aff_id=test', 'http://example.org/?aff_id=aff_code'],
-            ['http://www.foo.bar/?aff_id=test&aff_id2=test2', 'http://www.foo.bar/?aff_id=test&aff_id2=aff_code2'],
-        ];
+        $this->assertEquals(
+            ['https://example.com?aff_id=aff_code', true],
+            $this->extension->addAffiliateCode('https://example.com')
+        );
     }
 
     public function bool2strDataProvider()


### PR DESCRIPTION
This PR adds a little disclaimer to our affiliate links and also explains that automatically add affiliate parameters to certain URLs.
I extracted the affiliate link handling into a separate service and added a `getDomains` method.

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/361"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/be080150e920ec7f210f3481fc341d1542fd978a.svg" /></a>

