### PR TITLE
Deploy PRs to Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
       npm install npm@^6 -g
 
       npm install;
-      npm run prod;
+      npm run build;
     fi;
 
 before_script:

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: heroku-php-nginx -C scripts/heroku-nginx.conf web/

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Browser tests require Google Chrome with remote debugging enabled as well as the
 To do that, execute `bash scripts/prepare-browser-tests.sh` *once* before executing the tests. There is no
 need to call the script again until you reboot. Then execute the following to run the browser tests:
 ```bash
-npm run prod
+npm run build
 php bin/console cache:clear --env test
 php vendor/symfony/phpunit-bridge/bin/simple-phpunit --testsuite browser
 ```

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "addons": [
+    "heroku-postgresql:hobby-dev",
+    "bonsai:sandbox-6"
+  ],
+  "buildpacks": [
+    { "url": "heroku/nodejs" },
+    { "url": "heroku/php" }
+  ],
+  "env": {
+    "SYMFONY_ENV": {
+      "description": "Symfony Environment",
+      "value": "heroku"
+    }
+  }
+}

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -22,6 +22,7 @@ class AppKernel extends Kernel
             new DataDog\AuditBundle\DataDogAuditBundle(),
             new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
             new EWZ\Bundle\RecaptchaBundle\EWZRecaptchaBundle(),
+            new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
@@ -30,7 +31,6 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Symfony\Bundle\MakerBundle\MakerBundle();
-            $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
             if ('test' === $this->getEnvironment()) {
                 $bundles[] = new Liip\FunctionalTestBundle\LiipFunctionalTestBundle();
             }

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -8,8 +8,6 @@ imports:
 # http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en
-    elasticsearch:
-        index_name: 'adventure'
     container.dumper.inline_class_loader: true
     container.autowiring.strict_mode: true
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -51,7 +51,7 @@ twig:
 # Doctrine Configuration
 doctrine:
     dbal:
-        driver: pdo_mysql
+        driver: '%database_driver%'
         host: '%database_host%'
         port: '%database_port%'
         dbname: '%database_name%'

--- a/app/config/config_heroku.yml
+++ b/app/config/config_heroku.yml
@@ -1,0 +1,24 @@
+imports:
+    - { resource: config.yml }
+
+parameters:
+    elasticsearch_host: "%env(BONSAI_URL)%"
+    announcement: >
+        This is a preview build of AdventureLookup running on Heroku.
+        Please be aware that this preview is using PostgreSQL rather than MySQL,
+        which may lead to bugs that you cannot reproduce in your development environment.
+
+monolog:
+    handlers:
+        nested:
+            type:  stream
+            path:  "php://stderr"
+            level: debug
+
+doctrine:
+    dbal:
+        url: "%env(DATABASE_URL)%"
+        charset: utf8
+        default_table_options:
+            charset: utf8
+            collate: utf8_unicode_ci

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -40,3 +40,6 @@ parameters:
 
     affiliate_mappings: []
     announcement: ~
+
+    elasticsearch_host: 'localhost:9200'
+    elasticsearch_index_name: 'adventure'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -2,6 +2,7 @@
 # Set parameters here that may be different on each deployment target of the app, e.g. development, staging, production.
 # http://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 parameters:
+    database_driver: pdo_mysql
     database_host: 127.0.0.1
     database_port: ~
     database_name: adl

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -20,7 +20,8 @@ services:
 
     AppBundle\Service\ElasticSearch:
         arguments:
-            $config: "%elasticsearch%"
+            $host: "%elasticsearch_host%"
+            $indexName: "%elasticsearch_index_name%"
         tags:
             - { name: monolog.logger, channel: elasticsearch }
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "data-dog/audit-bundle": "^v0.1.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
+        "doctrine/doctrine-fixtures-bundle": "^2.3",
         "doctrine/doctrine-migrations-bundle": "^1.0",
         "doctrine/orm": "^2.5",
         "easycorp/easyadmin-bundle": "^1.16",
@@ -49,7 +50,6 @@
         "behat/mink": "^1.7",
         "behat/mink-browserkit-driver": "^1.3",
         "dmore/chrome-mink-driver": "^2.6",
-        "doctrine/doctrine-fixtures-bundle": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.16",
         "liip/functional-test-bundle": "^1.8",
         "symfony/maker-bundle": "^1.1",
@@ -75,6 +75,13 @@
         ],
         "lint": [
             "php-cs-fixer fix --config=.php_cs.dist --dry-run -v --diff"
+        ],
+        "compile": [
+            "[ \"$SYMFONY_ENV\" = \"heroku\" ]",
+            "php bin/console doctrine:schema:drop --no-interaction --full-database --force",
+            "php bin/console doctrine:schema:create --no-interaction",
+            "php bin/console doctrine:fixtures:load --no-interaction --fixtures src/AppBundle/DataFixtures/ORM/RandomAdventureData.php --fixtures src/AppBundle/DataFixtures/ORM/TestUserData.php",
+            "php bin/console app:elasticsearch:reindex --no-interaction"
         ]
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b398d83b693bbdc60088ab95f3ea3f26",
+    "content-hash": "36e616a986d7951991fdd82811a96a9b",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -484,6 +484,70 @@
             "time": "2020-05-15T05:51:54+00:00"
         },
         {
+            "name": "doctrine/data-fixtures",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "39e9777c9089351a468f780b01cffa3cb0a42907"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/39e9777c9089351a468f780b01cffa3cb0a42907",
+                "reference": "39e9777c9089351a468f780b01cffa3cb0a42907",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.11",
+                "doctrine/persistence": "^1.3.3",
+                "php": "^7.2"
+            },
+            "conflict": {
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^6.0",
+                "doctrine/dbal": "^2.5.4",
+                "doctrine/mongodb-odm": "^1.3.0",
+                "doctrine/orm": "^2.7.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM with PHP 7",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "lib/Doctrine/Common/DataFixtures"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "time": "2020-01-17T11:11:28+00:00"
+        },
+        {
             "name": "doctrine/dbal",
             "version": "2.10.2",
             "source": {
@@ -789,6 +853,63 @@
                 "caching"
             ],
             "time": "2019-11-29T11:22:01+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "v2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "74b8cc70a4a25b774628ee59f4cdf3623a146273"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/74b8cc70a4a25b774628ee59f4cdf3623a146273",
+                "reference": "74b8cc70a4a25b774628ee59f4cdf3623a146273",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "~1.0",
+                "doctrine/doctrine-bundle": "~1.0",
+                "php": ">=5.3.2",
+                "symfony/doctrine-bridge": "~2.7|~3.0|~4.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "time": "2017-10-30T19:26:42+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
@@ -5812,127 +5933,6 @@
             ],
             "description": "Mink driver for controlling chrome without selenium",
             "time": "2019-03-30T09:22:58+00:00"
-        },
-        {
-            "name": "doctrine/data-fixtures",
-            "version": "1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/data-fixtures.git",
-                "reference": "39e9777c9089351a468f780b01cffa3cb0a42907"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/39e9777c9089351a468f780b01cffa3cb0a42907",
-                "reference": "39e9777c9089351a468f780b01cffa3cb0a42907",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/common": "^2.11",
-                "doctrine/persistence": "^1.3.3",
-                "php": "^7.2"
-            },
-            "conflict": {
-                "doctrine/phpcr-odm": "<1.3.0"
-            },
-            "require-dev": {
-                "alcaeus/mongo-php-adapter": "^1.1",
-                "doctrine/coding-standard": "^6.0",
-                "doctrine/dbal": "^2.5.4",
-                "doctrine/mongodb-odm": "^1.3.0",
-                "doctrine/orm": "^2.7.0",
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "alcaeus/mongo-php-adapter": "For using MongoDB ODM with PHP 7",
-                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
-                "doctrine/orm": "For loading ORM fixtures",
-                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\DataFixtures\\": "lib/Doctrine/Common/DataFixtures"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                }
-            ],
-            "description": "Data Fixtures for all Doctrine Object Managers",
-            "homepage": "http://www.doctrine-project.org",
-            "keywords": [
-                "database"
-            ],
-            "time": "2020-01-17T11:11:28+00:00"
-        },
-        {
-            "name": "doctrine/doctrine-fixtures-bundle",
-            "version": "v2.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
-                "reference": "74b8cc70a4a25b774628ee59f4cdf3623a146273"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/74b8cc70a4a25b774628ee59f4cdf3623a146273",
-                "reference": "74b8cc70a4a25b774628ee59f4cdf3623a146273",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/data-fixtures": "~1.0",
-                "doctrine/doctrine-bundle": "~1.0",
-                "php": ">=5.3.2",
-                "symfony/doctrine-bridge": "~2.7|~3.0|~4.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Bundle\\FixturesBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Doctrine Project",
-                    "homepage": "http://www.doctrine-project.org"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Symfony DoctrineFixturesBundle",
-            "homepage": "http://www.doctrine-project.org",
-            "keywords": [
-                "Fixture",
-                "persistence"
-            ],
-            "time": "2017-10-30T19:26:42+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev-server-gitpod": "encore dev-server --hot --port 8002 --public $(gp url 8002) --disable-host-check",
     "format": "prettier --write app/Resources/**/*.{js,jsx}",
     "lint": "prettier --check app/Resources/**/*.{js,jsx}",
-    "prod": "encore production"
+    "build": "encore production"
   },
   "dependencies": {
     "autosize": "^4.0.2",
@@ -46,5 +46,9 @@
   "browserslist": [
     "> 1%",
     "last 2 versions"
-  ]
+  ],
+  "engines": {
+    "npm": "6.x",
+    "node": "12.x"
+  }
 }

--- a/scripts/heroku-nginx.conf
+++ b/scripts/heroku-nginx.conf
@@ -1,0 +1,18 @@
+# Based on
+# https://devcenter.heroku.com/articles/deploying-symfony3#creating-an-nginx-configuration-include
+
+location / {
+    # try to serve file directly, fallback to rewrite
+    try_files $uri @rewriteapp;
+}
+
+location @rewriteapp {
+    # rewrite all to app_heroku.php
+    rewrite ^(.*)$ /app_heroku.php/$1 last;
+}
+
+location ~ ^/(app|app_dev|app_heroku|config)\.php(/|$) {
+    try_files @heroku-fcgi @heroku-fcgi;
+    # ensure that /app_heroku.php isn't accessible directly, but only through a rewrite
+    internal;
+}

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -18,9 +18,9 @@ rm -rf var/cache/prod/*
 export SYMFONY_ENV=prod
 composer install --no-dev --optimize-autoloader -n
 npm install
-npm run prod
+npm run build
 php bin/console doctrine:migrations:migrate -n
 php bin/console app:elasticsearch:reindex -n
 rm -fR var/sessions/prod/*
-rm -f web/config.php web/app_dev.php web/app_test.php
+rm -f web/config.php web/app_dev.php web/app_test.php web/app_dev_heroku.php
 exit 0

--- a/src/AppBundle/Controller/AdventureController.php
+++ b/src/AppBundle/Controller/AdventureController.php
@@ -10,8 +10,8 @@ use AppBundle\Form\Type\AdventureType;
 use AppBundle\Form\Type\ReviewType;
 use AppBundle\Security\AdventureVoter;
 use AppBundle\Service\AdventureSearch;
+use AppBundle\Service\TimeProvider;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -134,26 +134,14 @@ class AdventureController extends Controller
      *
      * @return Response
      */
-    public function randomAction(EntityManagerInterface $em)
+    public function randomAction(AdventureSearch $adventureSearch, TimeProvider $timeProvider)
     {
-        $rsm = new ResultSetMapping();
-        $rsm->addEntityResult(Adventure::class, 'a');
-        $rsm->addFieldResult('a', 'id', 'id');
-        $rsm->addFieldResult('a', 'slug', 'slug');
-
-        $query = $em->createNativeQuery('
-            SELECT a.id, a.slug from adventure a ORDER by RAND() limit 1
-        ', $rsm);
-
-        $randomAdventure = $query->getResult();
-
-        $a = $randomAdventure[0];
-
-        if (!$a) {
+        list($adventures) = $adventureSearch->search('', [], 1, 'random', $timeProvider->millis(), 1);
+        if (empty($adventures)) {
             throw $this->createNotFoundException('No adventure found');
         }
 
-        return $this->redirectToRoute('adventure_show', ['slug' => $a->getSlug()]);
+        return $this->redirectToRoute('adventure_show', ['slug' => $adventures[0]->getSlug()]);
     }
 
     /**

--- a/src/AppBundle/DataFixtures/ORM/TestUserData.php
+++ b/src/AppBundle/DataFixtures/ORM/TestUserData.php
@@ -3,21 +3,24 @@
 namespace AppBundle\DataFixtures\ORM;
 
 use AppBundle\Entity\User;
-use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 
-class TestUserData implements FixtureInterface
+class TestUserData extends Fixture
 {
     /**
      * Load a list of test users for development purposes
      */
     public function load(ObjectManager $em)
     {
-        // NEVER RUN THIS ON PRODUCTION
+        if (!in_array($this->container->getParameter('kernel.environment'), ['dev', 'test', 'heroku'], true)) {
+            throw new \Exception('You can only load test user data when Symfony is running in a dev or test environment.');
+        }
+
         $data = [
-            ['username' => 'user', 'email' => 'user@test.com', 'roles' => ['ROLE_USER']],
-            ['username' => 'curator', 'email' => 'curator@test.com', 'roles' => ['ROLE_CURATOR']],
-            ['username' => 'admin', 'email' => 'admin@test.com', 'roles' => ['ROLE_ADMIN']],
+            ['username' => 'user', 'email' => 'user@example.com', 'roles' => ['ROLE_USER']],
+            ['username' => 'curator', 'email' => 'curator@example.com', 'roles' => ['ROLE_CURATOR']],
+            ['username' => 'admin', 'email' => 'admin@example.com', 'roles' => ['ROLE_ADMIN']],
         ];
 
         foreach ($data as $d) {

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 
 /**
- * @ORM\Table(name="user")
+ * @ORM\Table(name="`user`")
  * @ORM\Entity()
  * @UniqueEntity(fields="email", message="Email already taken")
  * @UniqueEntity(fields="username", message="Username already taken")

--- a/src/AppBundle/Service/AdventureSearch.php
+++ b/src/AppBundle/Service/AdventureSearch.php
@@ -138,7 +138,7 @@ class AdventureSearch
      *
      * @return array
      */
-    public function search(string $q, array $filters, int $page, string $sortBy, string $seed)
+    public function search(string $q, array $filters, int $page, string $sortBy, string $seed, int $perPage = self::ADVENTURES_PER_PAGE)
     {
         if ($page < 1 || $page * self::ADVENTURES_PER_PAGE > 5000) {
             throw new BadRequestHttpException();
@@ -221,8 +221,8 @@ class AdventureSearch
             'index' => $this->indexName,
             'body' => [
                 'query' => $query,
-                'from' => self::ADVENTURES_PER_PAGE * ($page - 1),
-                'size' => self::ADVENTURES_PER_PAGE,
+                'from' => $perPage * ($page - 1),
+                'size' => $perPage,
                 // Also return aggregations for all fields, i.e. min/max for integer fields
                 // or the most common strings for string fields.
                 'aggs' => $this->fieldAggregations(),

--- a/src/AppBundle/Service/ElasticSearch.php
+++ b/src/AppBundle/Service/ElasticSearch.php
@@ -18,10 +18,13 @@ class ElasticSearch
      */
     private $client;
 
-    public function __construct(ClientBuilder $clientBuilder, LoggerInterface $logger, array $config)
+    public function __construct(ClientBuilder $clientBuilder, LoggerInterface $logger, string $host, string $indexName)
     {
-        $this->client = $clientBuilder->setLogger($logger)->build();
-        $this->indexName = $config['index_name'];
+        $this->client = $clientBuilder
+            ->setLogger($logger)
+            ->setHosts([$host])
+            ->build();
+        $this->indexName = $indexName;
     }
 
     public function getIndexName(): string

--- a/tests/AppBundle/Service/ElasticSearchTest.php
+++ b/tests/AppBundle/Service/ElasticSearchTest.php
@@ -10,8 +10,8 @@ use Psr\Log\LoggerInterface;
 
 class ElasticSearchTest extends TestCase
 {
+    const HOST = 'localhost:9200';
     const INDEX_NAME = 'some_index';
-    const TYPE_NAME = 'some_type';
 
     /**
      * @var ElasticSearch
@@ -33,13 +33,13 @@ class ElasticSearchTest extends TestCase
             ->method('setLogger')
             ->with($logger)
             ->willReturnSelf();
+        $clientBuilder
+            ->expects($this->once())
+            ->method('setHosts')
+            ->with([self::HOST])
+            ->willReturnSelf();
         $clientBuilder->method('build')->willReturn($this->client);
-        $config = [
-            'index_name' => self::INDEX_NAME,
-            'type_name' => self::TYPE_NAME,
-        ];
-
-        $this->elasticSearch = new ElasticSearch($clientBuilder, $logger, $config);
+        $this->elasticSearch = new ElasticSearch($clientBuilder, $logger, self::HOST, self::INDEX_NAME);
     }
 
     public function testGetIndexName()

--- a/web/app_heroku.php
+++ b/web/app_heroku.php
@@ -1,0 +1,32 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+
+if ($_ENV['SYMFONY_ENV'] != "heroku") {
+    header('HTTP/1.0 403 Forbidden');
+    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+}
+
+/** @var \Composer\Autoload\ClassLoader $loader */
+$loader = require __DIR__.'/../app/autoload.php';
+include_once __DIR__.'/../var/bootstrap.php.cache';
+
+$kernel = new AppKernel('heroku', false);
+//$kernel = new AppCache($kernel);
+
+// When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
+//Request::enableHttpMethodParameterOverride();
+$request = Request::createFromGlobals();
+
+// https://devcenter.heroku.com/articles/deploying-symfony3#trusting-the-heroku-router
+Request::setTrustedProxies(
+    // trust *all* requests
+    ['127.0.0.1', $request->server->get('REMOTE_ADDR')],
+
+    // only trust X-Forwarded-Port/-Proto, not -Host
+    Request::HEADER_X_FORWARDED_AWS_ELB
+);
+
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);


### PR DESCRIPTION
This PR sets up Heroku review apps. Review apps are created for every PR and allow testing PRs more easily. To make AdventureLookup run on Heroku, only minor changes have been necessary:
- Use ElasticSearch instead of MySQL for random adventures (Heroku uses PostgreSQL instead of MySQL)
- Install fixture bundle in production (Heroku does not install dev dependencies, and we need the fixture bundle for dummy adventures)
- Make ElasticSearch host configurable
- Rename npm `prod` script to `build`, as expected by Heroku
- Create less sample adventures to not run into memory and database limits

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/369"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/9c5785ac0277d048e39b8b629d6b1f13b4c11e54.svg" /></a>

