### PR TITLE
Add disclaimer that data may be wrong

### DIFF
--- a/app/Resources/views/adventure/_details.html.twig
+++ b/app/Resources/views/adventure/_details.html.twig
@@ -201,16 +201,17 @@
                 </ul>
             </div>
         </div>
-        {% if affiliateCodeAdded %}
-            <div class="detail-row">
-                <div class="col">
-                    <p id="affiliate-link-info" class="text-muted">
+        <div class="detail-row">
+            <div class="col meta">
+                {% if affiliateCodeAdded %}
+                    <p id="affiliate-link-info">
                         <sup>1</sup> This is an affiliate link.
                         We may get a small comission if you buy something using that link.
                         There are no additional costs for you.
                     </p>
-                </div>
+                {% endif %}
+                <em>{{ disclaimer }}</em>
             </div>
-        {% endif %}
+        </div>
     </div>
 </div>

--- a/app/Resources/views/footer.html.twig
+++ b/app/Resources/views/footer.html.twig
@@ -42,5 +42,10 @@
                 </p>
             </div>
         </div>
+        <div class="row">
+            <div class="col">
+                <p id="disclaimer"><em>{{ disclaimer }}</em></p>
+            </div>
+        </div>
     </div>
 </footer>

--- a/app/Resources/webpack/sass/_adventure.scss
+++ b/app/Resources/webpack/sass/_adventure.scss
@@ -10,6 +10,7 @@ $thumbnail-height: 100px;
 
 .adventure-container {
   @extend .content-container;
+  padding-bottom: 0 !important;
 
   .thumbnail-container {
     position: absolute;
@@ -77,6 +78,11 @@ $thumbnail-height: 100px;
         margin-bottom: 0;
       }
     }
+  }
+
+  .meta {
+    font-size: 10px;
+    color: $text-muted;
   }
 }
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,6 +10,12 @@ parameters:
     locale: en
     container.dumper.inline_class_loader: true
     container.autowiring.strict_mode: true
+    disclaimer: |
+        Disclaimer: All information listed on this website comes with absolutely no warranty and may be incomplete or outright wrong.
+        We rely on contributors from the community to add and curate adventure data.
+        The publisher and original adventure authors are not usually involved in the process.
+        In many cases, we have no way to verify that the data we show for an adventure accurately represents the adventure's content.
+        If you find incomplete or wrong data, please login and create a change request on the adventure details page.
 
 framework:
     #esi: ~
@@ -47,6 +53,7 @@ twig:
     globals:
         google_analytics_code: '%google_analytics_code%'
         announcement: '%announcement%'
+        disclaimer: '%disclaimer%'
 
 # Doctrine Configuration
 doctrine:


### PR DESCRIPTION
I feel like a disclaimer that explicitly states that all data displayed on AdventureLookup.com comes without warranty and may be incomplete or wrong is a good thing to have.
If you have suggestions for improved wording, let me know.

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/387"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/55627ea50243452a7dfc57e453be22ee348152c0.svg" /></a>

