### PR TITLE
Make sort order of fields in filter bar configurable

### DIFF
--- a/app/Resources/webpack/js/adventures_filter.jsx
+++ b/app/Resources/webpack/js/adventures_filter.jsx
@@ -8,7 +8,8 @@ import { Root } from "./adventures_filter/Root";
   }
 
   const root = document.getElementById("sidebar-react-root");
-  const fieldData = Object.values(JSON.parse(root.dataset.fields));
+  const fields = Object.values(JSON.parse(root.dataset.fields));
+  fields.sort((a, b) => b.filterbarSort - a.filterbarSort);
   const initialFilterValues = JSON.parse(root.dataset.initialFilterValues);
   const url = root.dataset.url;
   const initialQuery = root.dataset.initialQuery;
@@ -17,7 +18,7 @@ import { Root } from "./adventures_filter/Root";
   const fieldStats = JSON.parse(root.dataset.fieldStats);
   ReactDOM.render(
     <Root
-      fields={fieldData}
+      fields={fields}
       url={url}
       initialFilterValues={initialFilterValues}
       initialQuery={initialQuery}

--- a/src/AppBundle/Field/Field.php
+++ b/src/AppBundle/Field/Field.php
@@ -49,7 +49,9 @@ class Field implements \JsonSerializable
      */
     private $relatedEntityClass;
 
-    public function __construct(string $name, string $type, bool $multiple, bool $freetextSearchable, bool $availableAsFilter, string $title, string $description = null, int $searchBoost = 1, string $relatedEntityClass = null)
+    private int $filterbarSort;
+
+    public function __construct(string $name, string $type, bool $multiple, bool $freetextSearchable, bool $availableAsFilter, string $title, string $description = null, int $searchBoost = 1, int $filterbarSort = 0, string $relatedEntityClass = null)
     {
         $this->name = $name;
         $this->type = $type;
@@ -60,6 +62,7 @@ class Field implements \JsonSerializable
         $this->availableAsFilter = $availableAsFilter;
         $this->searchBoost = $searchBoost;
         $this->relatedEntityClass = $relatedEntityClass;
+        $this->filterbarSort = $filterbarSort;
     }
 
     public function getName(): string
@@ -105,6 +108,11 @@ class Field implements \JsonSerializable
         return $this->description;
     }
 
+    public function getFilterbarSort(): int
+    {
+        return $this->filterbarSort;
+    }
+
     public function getFieldNameForAggregation(): string
     {
         $field = $this->getName();
@@ -137,6 +145,7 @@ class Field implements \JsonSerializable
             'title' => $this->title,
             'description' => $this->description,
             'availableAsFilter' => $this->availableAsFilter,
+            'filterbarSort' => $this->filterbarSort,
         ];
     }
 }

--- a/src/AppBundle/Field/FieldProvider.php
+++ b/src/AppBundle/Field/FieldProvider.php
@@ -51,6 +51,7 @@ class FieldProvider
                 'Authors',
                 'Names of people with writing or story credits on the module. Do not include editors or designers.',
                 1,
+                10,
                 Author::class
             ),
             'edition' => new Field(
@@ -62,6 +63,7 @@ class FieldProvider
                 'System / Edition',
                 'The system the game was designed for and the edition of that system if there is one.',
                 1,
+                300,
                 Edition::class
             ),
             'environments' => new Field(
@@ -73,6 +75,7 @@ class FieldProvider
                 'Environments',
                 'The different types of environments the module will take place in.',
                 2,
+                290,
                 Environment::class
             ),
             'items' => new Field(
@@ -84,6 +87,7 @@ class FieldProvider
                 'Notable Items',
                 "The notable magic or non-magic items that are obtained in the module. Only include named items, don't include a +1 sword.",
                 2,
+                250,
                 Item::class
             ),
             'publisher' => new Field(
@@ -95,6 +99,7 @@ class FieldProvider
                 'Publisher',
                 'Publisher of the adventure.',
                 1,
+                30,
                 Publisher::class
             ),
             'setting' => new Field(
@@ -106,6 +111,7 @@ class FieldProvider
                 'Setting',
                 'The narrative universe the module is set in.',
                 1,
+                280,
                 Setting::class
             ),
             'commonMonsters' => new Field(
@@ -117,6 +123,7 @@ class FieldProvider
                 'Common Monsters',
                 'The common monsters featured in the module.',
                 2,
+                260,
                 Monster::class
             ),
             'bossMonsters' => new Field(
@@ -128,6 +135,7 @@ class FieldProvider
                 'Boss Monsters',
                 'The boss monsters and villains featured in the module.',
                 2,
+                270,
                 Monster::class
             ),
 
@@ -138,7 +146,9 @@ class FieldProvider
                 false,
                 true,
                 'Length (# of Pages)',
-                'Total page count of all written material in the module or at least primary string.'
+                'Total page count of all written material in the module or at least primary string.',
+                1,
+                160
             ),
             'minStartingLevel' => new Field(
                 'minStartingLevel',
@@ -147,7 +157,9 @@ class FieldProvider
                 false,
                 true,
                 'Min. Starting Level',
-                'The minimum level characters are expected to be when taking part in the module.'
+                'The minimum level characters are expected to be when taking part in the module.',
+                1,
+                190
             ),
             'maxStartingLevel' => new Field(
                 'maxStartingLevel',
@@ -156,7 +168,9 @@ class FieldProvider
                 false,
                 true,
                 'Max. Starting Level',
-                'The maximum level characters are expected to be when taking part in the module.'
+                'The maximum level characters are expected to be when taking part in the module.',
+                1,
+                180
             ),
             'startingLevelRange' => new Field(
                 'startingLevelRange',
@@ -165,7 +179,9 @@ class FieldProvider
                 false,
                 true,
                 'Starting Level Range',
-                'In case no min. / max. starting levels but rather low/medium/high are given.'
+                'In case no min. / max. starting levels but rather low/medium/high are given.',
+                1,
+                170
             ),
 
             'soloable' => new Field(
@@ -174,7 +190,10 @@ class FieldProvider
                 false,
                 false,
                 true,
-                'Suitable for Solo Play'
+                'Suitable for Solo Play',
+                null,
+                1,
+                70
             ),
             'pregeneratedCharacters' => new Field(
                 'pregeneratedCharacters',
@@ -182,7 +201,10 @@ class FieldProvider
                 false,
                 false,
                 true,
-                'Includes Pregenerated Characters'
+                'Has Pregenerated Characters',
+                'Whether or not this contains character sheets.',
+                1,
+                100
             ),
             'handouts' => new Field(
                 'handouts',
@@ -190,7 +212,10 @@ class FieldProvider
                 false,
                 false,
                 true,
-                'Handouts'
+                'Handouts',
+                'Whether or not handouts are provided.',
+                1,
+                90
             ),
             'tacticalMaps' => new Field(
                 'tacticalMaps',
@@ -198,7 +223,10 @@ class FieldProvider
                 false,
                 false,
                 true,
-                'Battle Mats'
+                'Battle Mats',
+                'Whether or not battle mats are provided.',
+                1,
+                80
             ),
 
             'foundIn' => new Field(
@@ -208,7 +236,9 @@ class FieldProvider
                 true,
                 true,
                 'Found In',
-                'If the adventure is part of a larger product, like a magazine or anthology, list it here.'
+                'If the adventure is part of a larger product, like a magazine or anthology, list it here.',
+                1,
+                5
             ),
             'partOf' => new Field(
                 'partOf',
@@ -217,7 +247,9 @@ class FieldProvider
                 true,
                 true,
                 'Part Of',
-                'The series of adventures that the module is a part of, if applicable.'
+                'The series of adventures that the module is a part of, if applicable.',
+                1,
+                5
             ),
             'year' => new Field(
                 'year',
@@ -226,7 +258,9 @@ class FieldProvider
                 false,
                 true,
                 'Publication Year',
-                'The year this adventure was first published.'
+                'The year this adventure was first published.',
+                1,
+                20
             ),
 
             'link' => new Field(

--- a/tests/AppBundle/Field/FieldTest.php
+++ b/tests/AppBundle/Field/FieldTest.php
@@ -15,6 +15,7 @@ class FieldTest extends TestCase
     const TITLE = 'Field Title';
     const DESCRIPTION = 'Field Description';
     const SEARCH_BOOST = 42;
+    const FILTERBAR_SORT = 123;
     const RELATED_ENTITY_CLASS = 'some related class';
 
     public function testDefaults()
@@ -37,7 +38,7 @@ class FieldTest extends TestCase
     public function testWithoutDefaults()
     {
         $field = new Field(self::NAME, self::TYPE, self::MULTIPLE, self::SEARCHABLE, self::FILTERABLE, self::TITLE,
-            self::DESCRIPTION, self::SEARCH_BOOST, self::RELATED_ENTITY_CLASS);
+            self::DESCRIPTION, self::SEARCH_BOOST, self::FILTERBAR_SORT, self::RELATED_ENTITY_CLASS);
 
         $this->assertSame(self::NAME, $field->getName());
         $this->assertSame(self::NAME, $field->getFieldNameForAggregation());
@@ -47,6 +48,7 @@ class FieldTest extends TestCase
         $this->assertSame(self::FILTERABLE, $field->isAvailableAsFilter());
         $this->assertSame(self::TITLE, $field->getTitle());
         $this->assertSame(self::DESCRIPTION, $field->getDescription());
+        $this->assertSame(self::FILTERBAR_SORT, $field->getFilterbarSort());
         $this->assertSame(self::SEARCH_BOOST, $field->getSearchBoost());
         $this->assertSame(true, $field->isRelatedEntity());
         $this->assertSame(self::RELATED_ENTITY_CLASS, $field->getRelatedEntityClass());
@@ -55,7 +57,7 @@ class FieldTest extends TestCase
     public function testJSONSerialization()
     {
         $field = new Field(self::NAME, self::TYPE, self::MULTIPLE, self::SEARCHABLE, self::FILTERABLE, self::TITLE,
-        self::DESCRIPTION, self::SEARCH_BOOST, self::RELATED_ENTITY_CLASS);
+        self::DESCRIPTION, self::SEARCH_BOOST, self::FILTERBAR_SORT, self::RELATED_ENTITY_CLASS);
 
         $this->assertEquals([
             'name' => self::NAME,
@@ -64,6 +66,7 @@ class FieldTest extends TestCase
             'title' => self::TITLE,
             'description' => self::DESCRIPTION,
             'availableAsFilter' => self::FILTERABLE,
+            'filterbarSort' => self::FILTERBAR_SORT,
         ], json_decode(json_encode($field), true));
     }
 

--- a/tests/AppBundle/Service/AdventureSerializerTest.php
+++ b/tests/AppBundle/Service/AdventureSerializerTest.php
@@ -105,9 +105,9 @@ class AdventureSerializerTest extends TestCase
     {
         $this->fieldProvider->method('getFields')->willReturn(new ArrayCollection([
             new Field('title', 'string', false, false, false, 'title'),
-            new Field('authors', 'string', true, false, true, 'authors', null, 1, Author::class),
-            new Field('publisher', 'string', false, false, true, 'publisher', null, 1, Publisher::class),
-            new Field('edition', 'string', false, false, true, 'edition', null, 1, Edition::class),
+            new Field('authors', 'string', true, false, true, 'authors', null, 1, 1, Author::class),
+            new Field('publisher', 'string', false, false, true, 'publisher', null, 1, 1, Publisher::class),
+            new Field('edition', 'string', false, false, true, 'edition', null, 1, 1, Edition::class),
         ]));
 
         $author1 = new Author();


### PR DESCRIPTION
I feel like the current sort order of filters in the search filter bar is not ideal. For example, I doubt that many people want to search by adventure author, yet the author field is the first filter field. This PR adds a new paramter to fields to control the sort order in the filter bar.

I also renamed "Includes pregenerated characters" to "Has pregenerated characters" so that it no longer needs two lines.

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/2145092/88270661-43c0d500-ccd6-11ea-8a47-13facb9ee29f.png)| ![image](https://user-images.githubusercontent.com/2145092/88270656-41f71180-ccd6-11ea-9b3c-4ce05d1ddc5f.png) |

Let me know what you think of the new ordering.


<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/390"><img src="https://gitpod.io/api/apps/github/pbs/github.com/cmfcmf/AdventureLookup.git/239b0c5968a4c7f0d488193da5616246b748685d.svg" /></a>

