### PR TITLE
Fix link color

### DIFF
--- a/app/Resources/webpack/sass/_general.scss
+++ b/app/Resources/webpack/sass/_general.scss
@@ -1,9 +1,9 @@
+a {
+  color: $white--font-color-link;
+}
+
 .content-container {
   @extend .card;
-
-  a {
-    color: $white--font-color-link;
-  }
 
   padding-bottom: $adl-body-padding;
   margin-top: $adl-body-margin-top;


### PR DESCRIPTION
This PR fixes a visual bug introduced by #379:
![image](https://user-images.githubusercontent.com/2145092/88271483-7a4b1f80-ccd7-11ea-829e-6a7a78e30819.png)

We cannot directly change the color of all card links, because that overwrites the color used by, e.g., buttons, list groups, etc. Instead, we simply change the link color globally, which _can_ be overwritten by other components.