### PR TITLE
Force usage of composer v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,7 @@ jobs:
         with:
           coverage: pcov
           php-version: ${{ matrix.php-version }}
-          tools: 
-            - cs2pr 
-            - composer:v1
+          tools: cs2pr, composer:v1
           extensions: sqlite
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           coverage: pcov
           php-version: ${{ matrix.php-version }}
-          tools: cs2pr
+          tools: cs2pr composer:v1
           extensions: sqlite
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
         with:
           coverage: pcov
           php-version: ${{ matrix.php-version }}
-          tools: cs2pr composer:v1
+          tools: 
+            - cs2pr 
+            - composer:v1
           extensions: sqlite
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
We don't seem to be compatible with v2 yet:
https://github.com/AdventureLookup/AdventureLookup/pull/402/checks?check_run_id=1532281674

<a href="https://gitpod.io/#https://github.com/AdventureLookup/AdventureLookup/pull/403"><img src="https://gitpod.io/api/apps/github/pbs/github.com/AdventureLookup/AdventureLookup.git/5eee6bb37d77a7bed0a855fa7daad2afc5f10d26.svg" /></a>

